### PR TITLE
GAP-2148: grant advert not publishing on selected date

### DIFF
--- a/src/main/resources/db/migration/V1_66__alter_scheduler_database_view.sql
+++ b/src/main/resources/db/migration/V1_66__alter_scheduler_database_view.sql
@@ -1,0 +1,22 @@
+-- Replace view for scheduler
+
+DROP VIEW IF EXISTS ADVERT_SCHEDULER_VIEW;
+
+CREATE VIEW ADVERT_SCHEDULER_VIEW AS
+SELECT GRANT_ADVERT_ID AS ID,
+    CASE
+        WHEN
+            STATUS = 'SCHEDULED'
+            AND (OPENING_DATE AT TIME ZONE 'Europe/London')::date <= (NOW() AT TIME ZONE 'Europe/London')::date
+        THEN 'PUBLISH'
+        WHEN
+            STATUS = 'PUBLISHED'
+            AND (CLOSING_DATE AT TIME ZONE 'Europe/London')::date <= ((NOW() AT TIME ZONE 'Europe/London')::date - interval '1' DAY)
+        THEN 'UNPUBLISH'
+    END AS ACTION
+FROM GRANT_ADVERT
+WHERE (
+    STATUS = 'SCHEDULED' AND (OPENING_DATE AT TIME ZONE 'Europe/London')::date <= (NOW() AT TIME ZONE 'Europe/London')::date
+) OR (
+    STATUS = 'PUBLISHED' AND (CLOSING_DATE AT TIME ZONE 'Europe/London')::date <= ((NOW() AT TIME ZONE 'Europe/London')::date - interval '1' DAY)
+);

--- a/src/main/resources/db/migration/V1_68__alter_scheduler_database_view.sql
+++ b/src/main/resources/db/migration/V1_68__alter_scheduler_database_view.sql
@@ -2,6 +2,9 @@
 
 DROP VIEW IF EXISTS ADVERT_SCHEDULER_VIEW;
 
+ALTER TABLE grant_advert ALTER COLUMN opening_date TYPE timestamp with time zone;
+ALTER TABLE grant_advert ALTER COLUMN closing_date TYPE timestamp with time zone;
+
 CREATE VIEW ADVERT_SCHEDULER_VIEW AS
 SELECT GRANT_ADVERT_ID AS ID,
     CASE


### PR DESCRIPTION
Discovered the database stored our opening/closing dates as `timestamp without time zone` whereas JPA stores as an instant, set to the `Europe/London` zone.

This PR changes the columns to support the timezone:
<img width="175" alt="Screenshot 2023-09-25 at 16 16 08" src="https://github.com/cabinetoffice/gap-find-admin-backend/assets/101722961/c34d6678-7aa4-480c-984e-210f48132104">

And additionally modifies the view to look backwards incase it missed any ads that needed publishing/unpublishing