### PR TITLE
'+' bugfix - refactor service to send a post request

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/ValidateSessionsRolesRequestBodyDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/ValidateSessionsRolesRequestBodyDTO.java
@@ -1,0 +1,13 @@
+package gov.cabinetoffice.gap.adminbackend.dtos;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Data
+public class ValidateSessionsRolesRequestBodyDTO {
+    private String emailAddress;
+    private String roles;
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/ValidateSessionsRolesRequestBodyDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/ValidateSessionsRolesRequestBodyDTO.java
@@ -8,6 +8,9 @@ import lombok.Setter;
 @Setter
 @Data
 public class ValidateSessionsRolesRequestBodyDTO {
+
     private String emailAddress;
+
     private String roles;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/UserService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/UserService.java
@@ -51,8 +51,8 @@ public class UserService {
         requestBody.setEmailAddress(emailAddress);
         requestBody.setRoles(roles);
 
-        final HttpEntity<ValidateSessionsRolesRequestBodyDTO> requestEntity =
-                new HttpEntity<ValidateSessionsRolesRequestBodyDTO>(requestBody);
+        final HttpEntity<ValidateSessionsRolesRequestBodyDTO> requestEntity = new HttpEntity<ValidateSessionsRolesRequestBodyDTO>(
+                requestBody);
 
         Boolean isAdminSessionValid = restTemplate.exchange(url, HttpMethod.POST, requestEntity, Boolean.class)
                 .getBody();

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/UserService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/UserService.java
@@ -3,6 +3,7 @@ package gov.cabinetoffice.gap.adminbackend.services;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cabinetoffice.gap.adminbackend.config.UserServiceConfig;
+import gov.cabinetoffice.gap.adminbackend.dtos.ValidateSessionsRolesRequestBodyDTO;
 import gov.cabinetoffice.gap.adminbackend.exceptions.UnauthorizedException;
 import gov.cabinetoffice.gap.adminbackend.repositories.GapUserRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.GrantApplicantRepository;
@@ -45,10 +46,15 @@ public class UserService {
     public Boolean verifyAdminRoles(final String emailAddress, final String roles) {
         // TODO: after admin-session token handling is aligned with applicant we should
         // use '/is-user-logged-in'
-        final String url = userServiceConfig.getDomain() + "/v2/validateSessionsRoles?emailAddress=" + emailAddress
-                + "&roles=" + roles;
-        final HttpEntity<String> requestEntity = new HttpEntity<>(null);
-        Boolean isAdminSessionValid = restTemplate.exchange(url, HttpMethod.GET, requestEntity, Boolean.class)
+        final String url = userServiceConfig.getDomain() + "/v2/validateSessionsRoles";
+        ValidateSessionsRolesRequestBodyDTO requestBody = new ValidateSessionsRolesRequestBodyDTO();
+        requestBody.setEmailAddress(emailAddress);
+        requestBody.setRoles(roles);
+
+        final HttpEntity<ValidateSessionsRolesRequestBodyDTO> requestEntity =
+                new HttpEntity<ValidateSessionsRolesRequestBodyDTO>(requestBody);
+
+        Boolean isAdminSessionValid = restTemplate.exchange(url, HttpMethod.POST, requestEntity, Boolean.class)
                 .getBody();
         if (isAdminSessionValid == null) {
             throw new UnauthorizedException("Invalid roles");

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/UserServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/UserServiceTest.java
@@ -101,26 +101,26 @@ class UserServiceTest {
     public void testVerifyAdminRolesValid() {
         String emailAddress = "admin@example.com";
         String roles = "[FIND, APPLY, ADMIN]";
-        String url = "http://example.com/v2/validateSessionsRoles?emailAddress=" + emailAddress + "&roles=" + roles;
+        String url = "http://example.com/v2/validateSessionsRoles";
         ResponseEntity<Boolean> responseEntity = new ResponseEntity<>(true, HttpStatus.OK);
 
-        when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(HttpEntity.class), eq(Boolean.class)))
+        when(restTemplate.exchange(eq(url), eq(HttpMethod.POST), any(HttpEntity.class), eq(Boolean.class)))
                 .thenReturn(responseEntity);
         when(userServiceConfig.getDomain()).thenReturn("http://example.com");
 
         userService.verifyAdminRoles(emailAddress, roles);
-        verify(restTemplate, times(1)).exchange(eq(url), eq(HttpMethod.GET), any(HttpEntity.class), eq(Boolean.class));
+        verify(restTemplate, times(1)).exchange(eq(url), eq(HttpMethod.POST), any(HttpEntity.class), eq(Boolean.class));
     }
 
     @Test
     public void testVerifyAdminRolesWhenUnauthorizedResponse() {
         String emailAddress = "admin@example.com";
         String roles = "[FIND, APPLY, ADMIN]";
-        String url = "http://example.com/v2/validateSessionsRoles?emailAddress=" + emailAddress + "&roles=" + roles;
+        String url = "http://example.com/v2/validateSessionsRoles";
         HttpHeaders requestHeaders = new HttpHeaders();
         ResponseEntity<Boolean> responseEntity = new ResponseEntity<>(null, HttpStatus.UNAUTHORIZED);
 
-        when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(HttpEntity.class), eq(Boolean.class)))
+        when(restTemplate.exchange(eq(url), eq(HttpMethod.POST), any(HttpEntity.class), eq(Boolean.class)))
                 .thenReturn(responseEntity);
         when(userServiceConfig.getDomain()).thenReturn("http://example.com");
 


### PR DESCRIPTION
fixes a bug where email addresses containing a + can't log in. (when the `verify-user-roles-in-middleware` flag is true)
The right side of the + was removed from the query string, fix is to use a post request instead