### PR TITLE
Fix trigger CD on push & create

### DIFF
--- a/.github/workflows/pushImage.yml
+++ b/.github/workflows/pushImage.yml
@@ -1,6 +1,7 @@
 name: Push Image Workflow
 
 on:
+  create:
   push:
     branches:
       - release/**
@@ -15,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # Need to check here as create event can't be filtered by branch name...
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
 
     steps:
@@ -48,6 +49,9 @@ jobs:
           path: ${{github.workspace}}/reports
 
   build:
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
Now triggers on creation & pushes to develop or release branches
- Annoyingly create cant specify branches, so an additional check is needed per job as per: https://github.com/orgs/community/discussions/26286#discussioncomment-3251208