### PR TITLE
GAP-1784: User can't assign grant to current owner

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/UserController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/UserController.java
@@ -108,6 +108,11 @@ public class UserController {
     public ResponseEntity checkNewAdminEmailIsValid(
             @RequestBody @Valid final CheckNewAdminEmailDto checkNewAdminEmailDto, final HttpServletRequest request) {
         final String jwt = HelperUtils.getJwtFromCookies(request, userServiceConfig.getCookieName());
+
+        if (checkNewAdminEmailDto.getEmailAddress().equals(checkNewAdminEmailDto.getOldEmailAddress())) {
+            throw new FieldViolationException("emailAddress", "This user already owns this grant.");
+        }
+
         try {
             userService.getGrantAdminIdFromUserServiceEmail(checkNewAdminEmailDto.getEmailAddress(), jwt);
         }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/CheckNewAdminEmailDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/CheckNewAdminEmailDto.java
@@ -18,4 +18,6 @@ public class CheckNewAdminEmailDto {
     @NotBlank(message = "Please enter an email address")
     private String emailAddress;
 
+    private String oldEmailAddress;
+
 }


### PR DESCRIPTION
Fixes missing AC on 1784.

<img width="1004" alt="Screenshot 2023-11-13 at 08 57 43" src="https://github.com/cabinetoffice/gap-find-admin-backend/assets/135323857/f78e7ed1-9835-47b2-9fa2-a6f00c4ee1ad">

