### PR TITLE
TMI2-422: added check for null value

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionService.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
@@ -133,8 +134,8 @@ public class GrantMandatoryQuestionService {
                             mandatoryValue(schemeId, "postcode", grantMandatoryQuestions.getPostcode()),
                             mandatoryValue(schemeId, "application amount",
                                     grantMandatoryQuestions.getFundingAmount().toString()),
-                            grantMandatoryQuestions.getCharityCommissionNumber(),
-                            grantMandatoryQuestions.getCompaniesHouseNumber()));
+                            Objects.requireNonNullElse(grantMandatoryQuestions.getCharityCommissionNumber(), ""),
+                            Objects.requireNonNullElse(grantMandatoryQuestions.getCompaniesHouseNumber(), "")));
             if (addOrgType) {
                 row.add(mandatoryValue(schemeId, "organisation type", grantMandatoryQuestions.getOrgType().toString()));
             }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionServiceTest.java
@@ -330,7 +330,7 @@ class GrantMandatoryQuestionServiceTest {
         @Test
         void givenDataWithoutCharityNumber_returnsExpectedData() {
             grantMandatoryQuestions.setCharityCommissionNumber(null);
-            EXPECTED_SPOTLIGHT_ROW.set(6,"");
+            EXPECTED_SPOTLIGHT_ROW.set(6, "");
             List<String> spotlightRow = grantMandatoryQuestionService.buildSingleSpotlightRow(grantMandatoryQuestions,
                     false);
             assertThat(spotlightRow).containsAll(EXPECTED_SPOTLIGHT_ROW);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionServiceTest.java
@@ -6,7 +6,6 @@ import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantMandatoryQuestions;
 import gov.cabinetoffice.gap.adminbackend.entities.SchemeEntity;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantMandatoryQuestionOrgType;
-import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.SpotlightExportException;
 import gov.cabinetoffice.gap.adminbackend.repositories.GrantMandatoryQuestionRepository;
 import org.apache.poi.ss.usermodel.Row;
@@ -326,6 +325,15 @@ class GrantMandatoryQuestionServiceTest {
 
             String actualMessage = exception.getMessage();
             assertThat(actualMessage).contains("Unable to find mandatory question data:");
+        }
+
+        @Test
+        void givenDataWithoutCharityNumber_returnsExpectedData() {
+            grantMandatoryQuestions.setCharityCommissionNumber(null);
+            EXPECTED_SPOTLIGHT_ROW.set(6,"");
+            List<String> spotlightRow = grantMandatoryQuestionService.buildSingleSpotlightRow(grantMandatoryQuestions,
+                    false);
+            assertThat(spotlightRow).containsAll(EXPECTED_SPOTLIGHT_ROW);
         }
 
     }


### PR DESCRIPTION
Inside `buildSingleSpotlightRow` method, non-mandatory value can be null and this was throwing a nullpointer exception when creating `List.of(null)` . I added a check so that if it's null, it will pass an empty string instead of null