### PR TITLE
TMI2-455/ send spotlight 401 error support email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@
             <artifactId>java-sdk</artifactId>
             <version>10.5.9</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>1.12.593</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/config/SNSConfig.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/config/SNSConfig.java
@@ -1,0 +1,20 @@
+package gov.cabinetoffice.gap.adminbackend.config;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@RequiredArgsConstructor
+public class SNSConfig {
+
+    @Primary
+    @Bean
+    public AmazonSNSClient getSnsClient() {
+        return (AmazonSNSClient) AmazonSNSClientBuilder.defaultClient();
+    }
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
@@ -6,6 +6,7 @@ import gov.cabinetoffice.gap.adminbackend.entities.SpotlightBatch;
 import gov.cabinetoffice.gap.adminbackend.entities.SpotlightSubmission;
 import gov.cabinetoffice.gap.adminbackend.enums.SpotlightBatchStatus;
 import gov.cabinetoffice.gap.adminbackend.mappers.SpotlightBatchMapper;
+import gov.cabinetoffice.gap.adminbackend.services.SnsService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightBatchService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightSubmissionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,6 +40,8 @@ public class SpotlightBatchController {
     private final SpotlightSubmissionService spotlightSubmissionService;
 
     private final SpotlightBatchMapper spotlightBatchMapper;
+
+    private final SnsService snsService;
 
     @GetMapping("/status/{status}/exists")
     @Operation(summary = "Check if a spotlight batch with the given status exists")
@@ -133,6 +136,14 @@ public class SpotlightBatchController {
                 spotlightSubmissionId, spotlightBatchId);
 
         return ResponseEntity.ok().body("Successfully added spotlight submission to spotlight batch");
+    }
+
+    // TODO delete this
+    @GetMapping("/sns-test")
+    public ResponseEntity<String> snsTest() {
+        final String response = snsService.spotlightOAuthDisconnected();
+
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SnsService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SnsService.java
@@ -1,0 +1,47 @@
+package gov.cabinetoffice.gap.adminbackend.services;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.PublishRequest;
+import lombok.RequiredArgsConstructor;
+import com.amazonaws.services.sns.model.PublishResult;
+import com.amazonaws.services.sns.model.AmazonSNSException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SnsService {
+
+    private final AmazonSNSClient snsClient;
+
+    @Value("${sns.topicArn}")
+    private String TOPIC_ARN;
+
+    private String publicMessageToTopic(String subject, String body) {
+        try {
+            final PublishRequest request = new PublishRequest(TOPIC_ARN, body, subject);
+            final PublishResult result = snsClient.publish(request);
+            return "Message with message id:" + result.getMessageId() + " sent.";
+
+        }
+        catch (AmazonSNSException e) {
+            return e.getErrorMessage();
+        }
+
+    }
+
+    public String spotlightOAuthDisconnected() {
+        final String subject = "Spotlight API has disconnected";
+        final String body = """
+                What do you need to do?
+
+                Go into the Super Admin Dashboard and reconnect it. Go into the integration tab and click ‘Reconnect’.
+
+                If the ‘Reconnect’ button fails to get the connection working, contact the Spotlight support team to investigate.
+
+                Once fixed, the data will be sent to Spotlight again automatically.\s""";
+
+        return publicMessageToTopic(subject, body);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.profiles.active=LOCAL
 # ignore-jwt can be used for local dev work - should be set to false in all envs other than LOCAL
 debug.ignore-jwt=false
 debug.grant-admin-id=1
@@ -52,3 +53,5 @@ feature.validate-user-roles-in-middleware=true
 feature.newMandatoryQuestionsEnabled=true
 
 spotlight-publisher.secret=spotlightPublisherSecret
+
+sns.topicArn=snsTopicARN

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SnsServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SnsServiceTest.java
@@ -1,0 +1,57 @@
+package gov.cabinetoffice.gap.adminbackend.services;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.AmazonSNSException;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class SnsServiceTest {
+
+    private static AmazonSNSClient snsClient;
+
+    private static SnsService snsService;
+
+    @BeforeAll
+    static void beforeAll() {
+        snsClient = mock(AmazonSNSClient.class);
+        snsService = new SnsService(snsClient);
+        ReflectionTestUtils.setField(snsService, "snsClient", snsClient);
+    }
+
+    @BeforeEach
+    void resetMocks() {
+        reset(snsClient);
+    }
+
+    @Nested
+    class spotlightOAuthDisconnected {
+
+        @Test
+        void successfullyPublishesMessage() {
+            final PublishResult mockResult = new PublishResult().withMessageId("mockMessageId");
+            when(snsClient.publish(any(PublishRequest.class))).thenReturn(mockResult);
+
+            final String result = snsService.spotlightOAuthDisconnected();
+
+            assertThat(result).isEqualTo("Message with message id:mockMessageId sent.");
+        }
+
+        @Test
+        void throwsException() {
+            when(snsClient.publish(any())).thenThrow(new AmazonSNSException("error publishing message"));
+            final String result = snsService.spotlightOAuthDisconnected();
+            assertThat(result).isEqualTo("error publishing message");
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Description
Sends a support email to findagrant@cabinetoffice.gov.uk when a 401 error is returned from spotlight

Ticket # and link
TMI2-455: https://technologyprogramme.atlassian.net/browse/TMI2-455

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):
<img width="1430" alt="Screenshot 2023-11-28 at 09 31 09" src="https://github.com/cabinetoffice/gap-find-admin-backend/assets/99667350/cdef7a12-bb7e-4ca2-9e80-aaab2cfbe5c7">

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
