### PR TITLE
TMI2-421 - Added missing call for spotlight validation error download

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
@@ -181,4 +181,26 @@ public class SpotlightBatchController {
         return ResponseEntity.ok().body(spotlightBatchErrorCount);
     }
 
+//    @GetMapping("/get-validation-error-files/{schemeId}")
+//    @Operation(summary = "Fetches the submission files with Spotlight validation errors")
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "Retrieved error type and count",
+//                    content = @Content(mediaType = "application/json",
+//                            schema = @Schema(implementation = Boolean.class))),
+//            @ApiResponse(responseCode = "404", description = "No Spotlight errors exist",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "403", description = "Insufficient permissions to check Spotlight errors",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "400", description = "Bad request",
+//                    content = @Content(mediaType = "application/json")) })
+//    public ResponseEntity<GetSpotlightBatchErrorCountDTO> retrieveSpotlightBatchErrorCount(
+//            @PathVariable final String schemeId) {
+//        log.info("Retrieving Spotlight errors for scheme {}", schemeId);
+//
+//        final GetSpotlightBatchErrorCountDTO spotlightBatchErrorCount = spotlightBatchService
+//                .getSpotlightBatchErrorCount(Integer.parseInt(schemeId));
+//
+//        return ResponseEntity.ok().body(spotlightBatchErrorCount);
+//    }
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
@@ -2,11 +2,11 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 
 import gov.cabinetoffice.gap.adminbackend.annotations.SpotlightPublisherHeaderValidator;
 import gov.cabinetoffice.gap.adminbackend.dtos.spotlightBatch.GetSpotlightBatchErrorCountDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.spotlight.SendToSpotlightDto;
 import gov.cabinetoffice.gap.adminbackend.dtos.spotlightBatch.SpotlightBatchDto;
 import gov.cabinetoffice.gap.adminbackend.entities.SpotlightBatch;
 import gov.cabinetoffice.gap.adminbackend.enums.SpotlightBatchStatus;
 import gov.cabinetoffice.gap.adminbackend.mappers.SpotlightBatchMapper;
+import gov.cabinetoffice.gap.adminbackend.services.FileService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightBatchService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightSubmissionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +17,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -26,7 +31,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.ByteArrayOutputStream;
 import java.util.UUID;
+
+import static gov.cabinetoffice.gap.adminbackend.controllers.SubmissionsController.EXPORT_CONTENT_TYPE;
 
 @Log4j2
 @RestController
@@ -40,6 +48,8 @@ public class SpotlightBatchController {
     private final SpotlightSubmissionService spotlightSubmissionService;
 
     private final SpotlightBatchMapper spotlightBatchMapper;
+
+    private FileService fileService;
 
     // check spring security whitelist before adding endpoints
 
@@ -181,26 +191,43 @@ public class SpotlightBatchController {
         return ResponseEntity.ok().body(spotlightBatchErrorCount);
     }
 
-//    @GetMapping("/get-validation-error-files/{schemeId}")
-//    @Operation(summary = "Fetches the submission files with Spotlight validation errors")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "Retrieved error type and count",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = Boolean.class))),
-//            @ApiResponse(responseCode = "404", description = "No Spotlight errors exist",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "403", description = "Insufficient permissions to check Spotlight errors",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "400", description = "Bad request",
-//                    content = @Content(mediaType = "application/json")) })
-//    public ResponseEntity<GetSpotlightBatchErrorCountDTO> retrieveSpotlightBatchErrorCount(
-//            @PathVariable final String schemeId) {
-//        log.info("Retrieving Spotlight errors for scheme {}", schemeId);
-//
-//        final GetSpotlightBatchErrorCountDTO spotlightBatchErrorCount = spotlightBatchService
-//                .getSpotlightBatchErrorCount(Integer.parseInt(schemeId));
-//
-//        return ResponseEntity.ok().body(spotlightBatchErrorCount);
-//    }
+    @Operation(summary = "Fetches the submission files with Spotlight validation errors")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Retrieved error type and count",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Boolean.class))),
+            @ApiResponse(responseCode = "404", description = "No Spotlight errors exist",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions to check Spotlight errors",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "Bad request",
+                    content = @Content(mediaType = "application/json")) })
+    @GetMapping("/get-validation-error-files/{schemeId}")
+    public ResponseEntity<InputStreamResource> exportSpotlightValidationErrorFiles(@PathVariable Integer schemeId) {
+        final ByteArrayOutputStream stream = spotlightBatchService.getFilteredSpotlightSubmissionsWithValidationErrors(schemeId);
+        final String exportFileName = "spotlight_checks.zip";
+        return getInputStreamResourceResponseEntity(schemeId, stream, exportFileName);
+    }
+
+    @NotNull
+    private ResponseEntity<InputStreamResource> getInputStreamResourceResponseEntity(@PathVariable Integer schemeId,
+                                                                                     ByteArrayOutputStream stream, String exportFileName) {
+        log.info("Started due diligence data export for scheme " + schemeId);
+        long start = System.currentTimeMillis();
+
+        final InputStreamResource resource = fileService.createTemporaryFile(stream, exportFileName);
+        final int length = stream.toByteArray().length;
+
+        // setting HTTP headers to tell caller we are returning a file
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(ContentDisposition.parse("attachment; filename=" + exportFileName));
+
+        long end = System.currentTimeMillis();
+        log.info("Finished due diligence data export for scheme " + schemeId + ". Export time in millis: "
+                + (end - start));
+
+        return ResponseEntity.ok().headers(headers).contentLength(length)
+                .contentType(MediaType.parseMediaType(EXPORT_CONTENT_TYPE)).body(resource);
+    }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
@@ -49,7 +49,7 @@ public class SpotlightBatchController {
 
     private final SpotlightBatchMapper spotlightBatchMapper;
 
-    private FileService fileService;
+    private final FileService fileService;
 
     // check spring security whitelist before adding endpoints
 
@@ -204,15 +204,16 @@ public class SpotlightBatchController {
                     content = @Content(mediaType = "application/json")) })
     @GetMapping("/get-validation-error-files/{schemeId}")
     public ResponseEntity<InputStreamResource> exportSpotlightValidationErrorFiles(@PathVariable Integer schemeId) {
-        final ByteArrayOutputStream stream = spotlightBatchService.getFilteredSpotlightSubmissionsWithValidationErrors(schemeId);
-        final String exportFileName = "spotlight_checks.zip";
+        final ByteArrayOutputStream stream = spotlightBatchService
+                .getFilteredSpotlightSubmissionsWithValidationErrors(schemeId);
+        final String exportFileName = "spotlight_validation_errors.zip";
         return getInputStreamResourceResponseEntity(schemeId, stream, exportFileName);
     }
 
     @NotNull
     private ResponseEntity<InputStreamResource> getInputStreamResourceResponseEntity(@PathVariable Integer schemeId,
-                                                                                     ByteArrayOutputStream stream, String exportFileName) {
-        log.info("Started due diligence data export for scheme " + schemeId);
+            ByteArrayOutputStream stream, String exportFileName) {
+        log.info("Started Spotlight validation error file export for scheme " + schemeId);
         long start = System.currentTimeMillis();
 
         final InputStreamResource resource = fileService.createTemporaryFile(stream, exportFileName);
@@ -223,7 +224,7 @@ public class SpotlightBatchController {
         headers.setContentDisposition(ContentDisposition.parse("attachment; filename=" + exportFileName));
 
         long end = System.currentTimeMillis();
-        log.info("Finished due diligence data export for scheme " + schemeId + ". Export time in millis: "
+        log.info("Finished Spotlight validation error file export for scheme " + schemeId + ". Export time in millis: "
                 + (end - start));
 
         return ResponseEntity.ok().headers(headers).contentLength(length)

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightBatchController.java
@@ -6,7 +6,6 @@ import gov.cabinetoffice.gap.adminbackend.dtos.spotlightBatch.SpotlightBatchDto;
 import gov.cabinetoffice.gap.adminbackend.entities.SpotlightBatch;
 import gov.cabinetoffice.gap.adminbackend.enums.SpotlightBatchStatus;
 import gov.cabinetoffice.gap.adminbackend.mappers.SpotlightBatchMapper;
-import gov.cabinetoffice.gap.adminbackend.services.SnsService;
 import gov.cabinetoffice.gap.adminbackend.services.FileService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightBatchService;
 import gov.cabinetoffice.gap.adminbackend.services.SpotlightSubmissionService;
@@ -24,13 +23,7 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.ByteArrayOutputStream;
 import java.util.UUID;
@@ -192,18 +185,7 @@ public class SpotlightBatchController {
         return ResponseEntity.ok().body(spotlightBatchErrorCount);
     }
 
-    @Operation(summary = "Fetches the submission files with Spotlight validation errors")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Retrieved error type and count",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = Boolean.class))),
-            @ApiResponse(responseCode = "404", description = "No Spotlight errors exist",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "403", description = "Insufficient permissions to check Spotlight errors",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad request",
-                    content = @Content(mediaType = "application/json")) })
-    @GetMapping("/get-validation-error-files/{schemeId}")
+    @GetMapping(value = "/get-validation-error-files/{schemeId}", produces = EXPORT_CONTENT_TYPE)
     public ResponseEntity<InputStreamResource> exportSpotlightValidationErrorFiles(@PathVariable Integer schemeId) {
         final ByteArrayOutputStream stream = spotlightBatchService
                 .getFilteredSpotlightSubmissionsWithValidationErrors(schemeId);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantMandatoryQuestionService.java
@@ -54,7 +54,8 @@ public class GrantMandatoryQuestionService {
 
     }
 
-    public ByteArrayOutputStream getValidationErrorChecks(List<GrantMandatoryQuestions> mandatoryQuestions, Integer schemeId) {
+    public ByteArrayOutputStream getValidationErrorChecks(List<GrantMandatoryQuestions> mandatoryQuestions,
+            Integer schemeId) {
         final List<GrantMandatoryQuestions> companiesAndCharitiesQuestions = mandatoryQuestions.stream()
                 .filter(s -> s.getOrgType().equals(GrantMandatoryQuestionOrgType.CHARITY)
                         || s.getOrgType().equals(GrantMandatoryQuestionOrgType.UNREGISTERED_CHARITY)
@@ -77,11 +78,11 @@ public class GrantMandatoryQuestionService {
 
     }
 
-    private ByteArrayOutputStream generateZipFile(List<GrantMandatoryQuestions> companiesAndCharitiesQuestions, List<GrantMandatoryQuestions> nonLimitedCompanyQuestions, Integer schemeId) {
+    private ByteArrayOutputStream generateZipFile(List<GrantMandatoryQuestions> companiesAndCharitiesQuestions,
+            List<GrantMandatoryQuestions> nonLimitedCompanyQuestions, Integer schemeId) {
         final List<List<String>> charitiesAndCompanies = exportSpotlightChecks(schemeId, companiesAndCharitiesQuestions,
                 false);
         final String charitiesAndCompaniesFilename = generateExportFileName(schemeId, " charities_and_companies");
-
 
         final List<List<String>> nonLimitedCompanies = exportSpotlightChecks(schemeId, nonLimitedCompanyQuestions,
                 false);
@@ -90,7 +91,6 @@ public class GrantMandatoryQuestionService {
         final List<List<List<String>>> dataList = List.of(charitiesAndCompanies, nonLimitedCompanies);
         final List<String> filenames = List.of(charitiesAndCompaniesFilename, nonLimitedCompaniesFilename);
         return zipService.createZip(SpotlightHeaders.SPOTLIGHT_HEADERS, dataList, filenames);
-
     }
 
     public ByteArrayOutputStream getDueDiligenceData(Integer schemeId) {

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchService.java
@@ -87,6 +87,8 @@ public class SpotlightBatchService {
 
     private final SpotlightSubmissionService spotlightSubmissionService;
 
+    private final GrantMandatoryQuestionService grantMandatoryQuestionService;
+
     public boolean existsByStatusAndMaxBatchSize(SpotlightBatchStatus status, int maxSize) {
         return spotlightBatchRepository.existsByStatusAndSpotlightSubmissionsSizeLessThan(status, maxSize);
     }
@@ -501,7 +503,6 @@ public class SpotlightBatchService {
         for(SpotlightSubmission submission: spotlightSubmissions) {
             mandatoryQuestions.add(submission.getMandatoryQuestions());
         }
-        final List<List<String>> exportData = exportSpotlightChecks(schemeId, mandatoryQuestions, true);
-        return XlsxGenerator.createResource(DueDiligenceHeaders.DUE_DILIGENCE_HEADERS, exportData);
+        return grantMandatoryQuestionService.getValidationErrorChecks(mandatoryQuestions, schemeId);
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
@@ -70,6 +70,9 @@ class SpotlightBatchServiceTest {
     Pageable pageable = PageRequest.of(0, 1);
 
     @Mock
+    private GrantMandatoryQuestionService grantMandatoryQuestionService;
+
+    @Mock
     private SpotlightBatchRepository spotlightBatchRepository;
 
     @Mock
@@ -110,7 +113,7 @@ class SpotlightBatchServiceTest {
         spotlightBatchService = Mockito
                 .spy(new SpotlightBatchService(spotlightBatchRepository, mandatoryQuestionsMapper, secretsManagerClient,
                         restTemplate, spotlightSubmissionRepository, spotlightConfigProperties, objectMapper,
-                        spotlightQueueProperties, amazonSqs, spotlightSubmissionService));
+                        spotlightQueueProperties, amazonSqs, spotlightSubmissionService, grantMandatoryQuestionService));
     }
 
     @Nested

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
@@ -110,10 +110,10 @@ class SpotlightBatchServiceTest {
                 .secretName("secretName").build();
         objectMapper = Mockito.spy(new ObjectMapper());
         spotlightQueueProperties = SpotlightQueueConfigProperties.builder().queueUrl("queueUrl").build();
-        spotlightBatchService = Mockito
-                .spy(new SpotlightBatchService(spotlightBatchRepository, mandatoryQuestionsMapper, secretsManagerClient,
-                        restTemplate, spotlightSubmissionRepository, spotlightConfigProperties, objectMapper,
-                        spotlightQueueProperties, amazonSqs, spotlightSubmissionService, grantMandatoryQuestionService));
+        spotlightBatchService = Mockito.spy(new SpotlightBatchService(spotlightBatchRepository,
+                mandatoryQuestionsMapper, secretsManagerClient, restTemplate, spotlightSubmissionRepository,
+                spotlightConfigProperties, objectMapper, spotlightQueueProperties, amazonSqs,
+                spotlightSubmissionService, grantMandatoryQuestionService));
     }
 
     @Nested

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
@@ -113,10 +113,10 @@ class SpotlightBatchServiceTest {
                 .secretName("secretName").build();
         objectMapper = Mockito.spy(new ObjectMapper());
         spotlightQueueProperties = SpotlightQueueConfigProperties.builder().queueUrl("queueUrl").build();
-        spotlightBatchService = Mockito
-                .spy(new SpotlightBatchService(spotlightBatchRepository, mandatoryQuestionsMapper, secretsManagerClient,
-                        restTemplate, spotlightSubmissionRepository, spotlightConfigProperties, objectMapper,
-                        spotlightQueueProperties, amazonSqs, spotlightSubmissionService, snsService, grantMandatoryQuestionService));
+        spotlightBatchService = Mockito.spy(new SpotlightBatchService(spotlightBatchRepository,
+                mandatoryQuestionsMapper, secretsManagerClient, restTemplate, spotlightSubmissionRepository,
+                spotlightConfigProperties, objectMapper, spotlightQueueProperties, amazonSqs,
+                spotlightSubmissionService, grantMandatoryQuestionService, snsService));
     }
 
     @Nested

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
@@ -45,11 +45,15 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static gov.cabinetoffice.gap.adminbackend.enums.DraftAssessmentResponseDtoStatus.FAILURE;
 import static gov.cabinetoffice.gap.adminbackend.enums.DraftAssessmentResponseDtoStatus.SUCCESS;
@@ -1300,6 +1304,52 @@ class SpotlightBatchServiceTest {
             assertEquals(0, result.getErrorCount());
             assertEquals("OK", result.getErrorStatus());
             assertFalse(result.isErrorFound());
+        }
+
+    }
+
+    @Nested
+    class getFilteredSpotlightSubmissionsWithValidationErrors {
+
+        final Integer schemeId = 1;
+
+        final SchemeEntity schemeEntity = SchemeEntity.builder().id(schemeId).build();
+
+        final List<SpotlightBatch> spotlightBatches = Collections
+                .singletonList(SpotlightBatch.builder().spotlightSubmissions(new ArrayList<>()).build());
+
+        private final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions.builder()
+                .name("Some company name").addressLine1("9-10 St Andrew Square").city("Edinburgh").county("county")
+                .postcode("EH2 2AF").charityCommissionNumber("500").companiesHouseNumber("12738494")
+                .orgType(GrantMandatoryQuestionOrgType.CHARITY).fundingAmount(BigDecimal.valueOf(50000))
+                .schemeEntity(schemeEntity).gapId("GAP-ID").build();
+
+        final List<GrantMandatoryQuestions> mandatoryQuestionsList = List.of(grantMandatoryQuestions);
+
+        final SpotlightSubmission spotlightSubmission = SpotlightSubmission.builder()
+                .status(SpotlightSubmissionStatus.VALIDATION_ERROR.toString()).grantScheme(schemeEntity)
+                .mandatoryQuestions(grantMandatoryQuestions).build();
+
+        @Test
+        void getFilteredSpotlightSubmissionsWithValidationErrors() throws IOException {
+            final ByteArrayOutputStream zipStream = new ByteArrayOutputStream();
+            try (ZipOutputStream zipOut = new ZipOutputStream(zipStream)) {
+                final ZipEntry entry = new ZipEntry("mock_excel_file.xlsx");
+                zipOut.putNextEntry(entry);
+                zipOut.write("Mock Excel File Content".getBytes());
+                zipOut.closeEntry();
+            }
+
+            when(spotlightBatchRepository.findMostRecentSpotlightBatch(pageable)).thenReturn(spotlightBatches);
+            spotlightBatches.get(0).getSpotlightSubmissions().add(spotlightSubmission);
+            when(grantMandatoryQuestionService.getValidationErrorChecks(mandatoryQuestionsList, schemeId))
+                    .thenReturn(zipStream);
+
+            final ByteArrayOutputStream result = spotlightBatchService
+                    .getFilteredSpotlightSubmissionsWithValidationErrors(schemeId);
+
+            verify(spotlightBatchRepository).findMostRecentSpotlightBatch(pageable);
+            assertThat(result).isEqualTo(zipStream);
         }
 
     }


### PR DESCRIPTION
## Description
Adds endpoint to download spotlight flies based grouped by orgType that had validation errors in Spotlight

Ticket # and link
TMI2-421: https://technologyprogramme.atlassian.net/browse/TMI2-421

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
