### PR TITLE
TMI2-454: send Spotlight API error support email

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SnsService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SnsService.java
@@ -45,4 +45,16 @@ public class SnsService {
         return publishMessageToTopic(subject, body);
     }
 
+    public String spotlightApiError() {
+        final String subject = "The API between Find and Spotlight is down";
+        final String body = """
+                What do you need to do?
+                                
+                Find out if it is a problem with Find or is a problem with Spotlight.
+                                
+                Once resolved, the service will start sending data to Spotlight again automatically.\s""";
+
+        return publishMessageToTopic(subject, body);
+    }
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchService.java
@@ -339,7 +339,11 @@ public class SpotlightBatchService {
         }
         catch (HttpServerErrorException e) {
             if (e.getStatusCode().is5xxServerError()) { // 5xx codes
-                // TODO send API error support email here
+                log.info("Sending spotlight API error support email using SNS for status code: "
+                        + e.getStatusCode());
+                final String snsResponse = snsService.spotlightApiError();
+                log.info(snsResponse);
+
                 log.error("Hitting {} returned status code {} with body {}", draftAssessmentsEndpoint,
                         e.getStatusCode(), e.getResponseBodyAsString());
             }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SnsServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SnsServiceTest.java
@@ -23,6 +23,10 @@ public class SnsServiceTest {
 
     private static SnsConfigProperties snsConfigProperties;
 
+    private final String MESSAGE_ID = "mockMessageId";
+
+    private final String ERROR = "error publishing message";
+
     @BeforeAll
     static void beforeAll() {
         snsConfigProperties = SnsConfigProperties.builder().topicArn("topicArn").build();
@@ -41,19 +45,41 @@ public class SnsServiceTest {
 
         @Test
         void successfullyPublishesMessage() {
-            final PublishResult mockResult = new PublishResult().withMessageId("mockMessageId");
+            final PublishResult mockResult = new PublishResult().withMessageId(MESSAGE_ID);
             when(snsClient.publish(any(PublishRequest.class))).thenReturn(mockResult);
 
             final String result = snsService.spotlightOAuthDisconnected();
 
-            assertThat(result).isEqualTo("Message with message id:mockMessageId sent.");
+            assertThat(result).isEqualTo("Message with message id:" + MESSAGE_ID + " sent.");
         }
 
         @Test
         void throwsException() {
-            when(snsClient.publish(any())).thenThrow(new AmazonSNSException("error publishing message"));
+            when(snsClient.publish(any())).thenThrow(new AmazonSNSException(ERROR));
             final String result = snsService.spotlightOAuthDisconnected();
-            assertThat(result).isEqualTo("Error publishing message to SNS topic with error: error publishing message");
+            assertThat(result).isEqualTo("Error publishing message to SNS topic with error: " + ERROR);
+        }
+
+    }
+
+    @Nested
+    class spotlightApiError {
+
+        @Test
+        void successfullyPublishesMessage() {
+            final PublishResult mockResult = new PublishResult().withMessageId(MESSAGE_ID);
+            when(snsClient.publish(any(PublishRequest.class))).thenReturn(mockResult);
+
+            final String result = snsService.spotlightApiError();
+
+            assertThat(result).isEqualTo("Message with message id:" + MESSAGE_ID + " sent.");
+        }
+
+        @Test
+        void throwsException() {
+            when(snsClient.publish(any())).thenThrow(new AmazonSNSException(ERROR));
+            final String result = snsService.spotlightApiError();
+            assertThat(result).isEqualTo("Error publishing message to SNS topic with error: " + ERROR);
         }
 
     }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SpotlightBatchServiceTest.java
@@ -917,6 +917,7 @@ class SpotlightBatchServiceTest {
             final SpotlightResponseResultsDto methodResponse = spotlightBatchService.sendBatchToSpotlight(batch,
                     accessToken);
 
+            verify(snsService).spotlightApiError();
             assertThat(methodResponse).isEqualTo(expectedResponse);
         }
 


### PR DESCRIPTION
## Description
Sends a support email to [findagrant@cabinetoffice.gov.uk](mailto:findagrant@cabinetoffice.gov.uk) when any 5xx error is returned from spotlight.
Here is the [SNS topic](https://eu-west-2.console.aws.amazon.com/sns/v3/home?region=eu-west-2#/topic/arn:aws:sns:eu-west-2:801347364784:gap-sandbox-spotlight-support)

Ticket # and link
TMI2-454: https://technologyprogramme.atlassian.net/browse/TMI2-454

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

<img width="1430" alt="Screenshot 2023-11-28 at 10 49 10" src="https://github.com/cabinetoffice/gap-find-admin-backend/assets/99667350/7b164ef2-44ce-4a51-9d27-ce0a37bd6138">

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
