### PR TITLE
TMI2-524: spotlight export row limit

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/constants/SpotlightExports.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/constants/SpotlightExports.java
@@ -1,0 +1,9 @@
+package gov.cabinetoffice.gap.adminbackend.constants;
+
+public class SpotlightExports {
+
+    public static final String REQUIRED_CHECKS_FILENAME = "required_checks.zip";
+
+    public static final String SPOTLIGHT_CHECKS_FILENAME = "spotlight_checks.zip";
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightSubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightSubmissionController.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
 import gov.cabinetoffice.gap.adminbackend.annotations.SpotlightPublisherHeaderValidator;
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.spotlightSubmissions.GetSpotlightSubmissionDataBySchemeIdDto;
 import gov.cabinetoffice.gap.adminbackend.dtos.spotlightSubmissions.SpotlightSubmissionDto;
@@ -110,9 +111,8 @@ public class SpotlightSubmissionController {
         final SchemeDTO scheme = schemeService.getSchemeBySchemeId(schemeId);
         final ByteArrayOutputStream stream = spotlightSubmissionService.generateDownloadFile(scheme,
                 onlyValidationErrors);
-        final String exportFileName = "spotlight_checks.zip";
 
-        return getInputStreamResourceResponseEntity(schemeId, stream, exportFileName);
+        return getInputStreamResourceResponseEntity(schemeId, stream, SpotlightExports.SPOTLIGHT_CHECKS_FILENAME);
     }
 
     @NotNull

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.UrlDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.submission.LambdaSubmissionDefinition;
@@ -51,18 +52,19 @@ public class SubmissionsController {
         long start = System.currentTimeMillis();
 
         final ByteArrayOutputStream stream = submissionsService.exportSpotlightChecks(applicationId);
-        final String exportFileName = "required_checks.zip";
-        final InputStreamResource resource = fileService.createTemporaryFile(stream, exportFileName);
+        final InputStreamResource resource = fileService.createTemporaryFile(stream,
+                SpotlightExports.REQUIRED_CHECKS_FILENAME);
 
         submissionsService.updateSubmissionLastRequiredChecksExport(applicationId);
 
         final int length = stream.toByteArray().length;
         log.info("Exporting spotlight checks for application ID {}, generated filename {} with length {}",
-                applicationId, exportFileName, length);
+                applicationId, SpotlightExports.REQUIRED_CHECKS_FILENAME, length);
 
         // setting HTTP headers to tell caller we are returning a file
         final HttpHeaders headers = new HttpHeaders();
-        headers.setContentDisposition(ContentDisposition.parse("attachment; filename=" + exportFileName));
+        headers.setContentDisposition(
+                ContentDisposition.parse("attachment; filename=" + SpotlightExports.REQUIRED_CHECKS_FILENAME));
 
         long end = System.currentTimeMillis();
         log.info("Finished submissions export for application " + applicationId + ". Export time in millis: "

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
@@ -51,7 +51,7 @@ public class SubmissionsController {
         long start = System.currentTimeMillis();
 
         final ByteArrayOutputStream stream = submissionsService.exportSpotlightChecks(applicationId);
-        final String exportFileName = submissionsService.generateExportFileName(applicationId);
+        final String exportFileName = "required_checks.zip";
         final InputStreamResource resource = fileService.createTemporaryFile(stream, exportFileName);
 
         submissionsService.updateSubmissionLastRequiredChecksExport(applicationId);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SubmissionsService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SubmissionsService.java
@@ -24,7 +24,6 @@ import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 import gov.cabinetoffice.gap.adminbackend.repositories.GrantExportRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.SubmissionRepository;
 import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
-import gov.cabinetoffice.gap.adminbackend.utils.XlsxGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -38,9 +37,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.ByteArrayOutputStream;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.*;
@@ -63,6 +59,8 @@ public class SubmissionsService {
     private final SubmissionMapper submissionMapper;
 
     private final RestTemplate restTemplate;
+
+    private final ZipService zipService;
 
     @Value("${cloud.aws.sqs.submissions-export-queue}")
     private String submissionsExportQueue;
@@ -91,17 +89,29 @@ public class SubmissionsService {
         log.info("Found {} submissions in SUBMITTED state for application ID {}", submissionsByAppId.size(),
                 applicationId);
 
-        List<List<String>> spotlightExportData = new ArrayList<>();
-        submissionsByAppId.forEach(submission -> {
-            try {
-                spotlightExportData.add(buildSingleSpotlightRow(submission));
-            }
-            catch (SpotlightExportException e) {
-                log.error("Problem extracting data: " + e.getMessage());
-            }
-        });
+        final List<List<List<String>>> dataList = new ArrayList<>();
+        final List<String> filenames = new ArrayList<>();
+        int index = 1;
 
-        return XlsxGenerator.createResource(SpotlightHeaders.SPOTLIGHT_HEADERS, spotlightExportData);
+        for (List<Submission> submissionList : Lists.partition(submissionsByAppId, 999)) {
+            final String filename = generateExportFileName(applicationId, index);
+            List<List<String>> spotlightExportData = new ArrayList<>();
+            submissionList.forEach(submission -> {
+                try {
+                    spotlightExportData.add(buildSingleSpotlightRow(submission));
+                }
+                catch (SpotlightExportException e) {
+                    log.error("Problem extracting data: " + e.getMessage());
+                }
+            });
+
+            dataList.add(spotlightExportData);
+            filenames.add(filename);
+
+            index++;
+        }
+
+        return zipService.createZip(SpotlightHeaders.SPOTLIGHT_HEADERS, dataList, filenames);
     }
 
     public void updateSubmissionLastRequiredChecksExport(Integer applicationId) {
@@ -177,7 +187,7 @@ public class SubmissionsService {
         }
     }
 
-    public String generateExportFileName(Integer applicationId) {
+    public String generateExportFileName(Integer applicationId, Integer count) {
         ApplicationFormDTO applicationFormDTO = applicationFormService.retrieveApplicationFormSummary(applicationId,
                 false, false);
         String ggisReference = schemeService.getSchemeBySchemeId(applicationFormDTO.getGrantSchemeId())
@@ -186,7 +196,7 @@ public class SubmissionsService {
                 "");
         String dateString = new SimpleDateFormat("yyyy-MM-dd").format(Calendar.getInstance().getTime());
 
-        return dateString + "_" + ggisReference + "_" + applicationName + ".xlsx";
+        return dateString + "_" + ggisReference + "_" + applicationName + "_" + count + ".xlsx";
     }
 
     public void triggerSubmissionsExport(Integer applicationId) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightSubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SpotlightSubmissionControllerTest.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
 import gov.cabinetoffice.gap.adminbackend.config.SpotlightPublisherInterceptor;
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.spotlightSubmissions.SpotlightSubmissionDto;
 import gov.cabinetoffice.gap.adminbackend.entities.SpotlightSubmission;
@@ -168,13 +169,12 @@ class SpotlightSubmissionControllerTest {
                 zipOut.write("Mock Excel File Content".getBytes());
                 zipOut.closeEntry();
             }
-            final String exportFileName = "spotlight_checks.zip";
             final SchemeDTO scheme = SchemeDTO.builder().schemeId(SCHEME_ID).build();
 
             when(schemeService.getSchemeBySchemeId(SCHEME_ID)).thenReturn(scheme);
             when(mockSpotlightSubmissionService.generateDownloadFile(scheme, false)).thenReturn(zipStream);
 
-            when(fileService.createTemporaryFile(zipStream, exportFileName))
+            when(fileService.createTemporaryFile(zipStream, SpotlightExports.SPOTLIGHT_CHECKS_FILENAME))
                     .thenReturn(new InputStreamResource(new ByteArrayInputStream(zipStream.toByteArray())));
 
             mockMvc.perform(

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
@@ -35,6 +35,8 @@ import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static gov.cabinetoffice.gap.adminbackend.controllers.SubmissionsController.EXPORT_CONTENT_TYPE;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,23 +84,29 @@ class SubmissionsControllerTest {
 
         @Test
         void exportSpotlightChecksHappyPathTest() throws Exception {
-            doReturn("test_file_name").when(submissionsService).generateExportFileName(1);
-            final byte[] data = exampleFile.getInputStream().readAllBytes();
-            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            outputStream.write(data);
-            final InputStreamResource inputStream = new InputStreamResource(
-                    new ByteArrayInputStream(outputStream.toByteArray()));
+            final ByteArrayOutputStream zipStream = new ByteArrayOutputStream();
+            try (ZipOutputStream zipOut = new ZipOutputStream(zipStream)) {
+                final ZipEntry entry = new ZipEntry("mock_excel_file.xlsx");
+                zipOut.putNextEntry(entry);
+                zipOut.write("Mock Excel File Content".getBytes());
+                zipOut.closeEntry();
+            }
+            final String exportFileName = "required_checks.zip";
 
-            when(fileService.createTemporaryFile(outputStream, "test_file_name")).thenReturn(inputStream);
-            when(submissionsService.exportSpotlightChecks(1)).thenReturn(outputStream);
+            when(fileService.createTemporaryFile(zipStream, exportFileName))
+                    .thenReturn(new InputStreamResource(new ByteArrayInputStream(zipStream.toByteArray()))
+
+                    );
+            when(submissionsService.exportSpotlightChecks(1)).thenReturn(zipStream);
             doNothing().when(submissionsService).updateSubmissionLastRequiredChecksExport(1);
 
             mockMvc.perform(get("/submissions/spotlight-export/" + 1)).andExpect(status().isOk())
-                    .andExpect(
-                            header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"test_file_name\""))
+                    .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"required_checks.zip\""))
                     .andExpect(header().string(HttpHeaders.CONTENT_TYPE, EXPORT_CONTENT_TYPE))
-                    .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, String.valueOf(data.length)))
-                    .andExpect(content().bytes(data));
+                    .andExpect(
+                            header().string(HttpHeaders.CONTENT_LENGTH, String.valueOf(zipStream.toByteArray().length)))
+                    .andExpect(content().bytes(zipStream.toByteArray()));
         }
 
         @Test
@@ -130,7 +138,7 @@ class SubmissionsControllerTest {
             final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             outputStream.write(data);
             when(submissionsService.exportSpotlightChecks(1)).thenReturn(outputStream);
-            when(submissionsService.generateExportFileName(1)).thenReturn("test_file_name");
+            when(submissionsService.generateExportFileName(1, 1)).thenReturn("test_file_name");
             doThrow(new RuntimeException("forced service error")).when(submissionsService)
                     .updateSubmissionLastRequiredChecksExport(1);
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.UrlDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.submission.LambdaSubmissionDefinition;
@@ -91,9 +92,8 @@ class SubmissionsControllerTest {
                 zipOut.write("Mock Excel File Content".getBytes());
                 zipOut.closeEntry();
             }
-            final String exportFileName = "required_checks.zip";
 
-            when(fileService.createTemporaryFile(zipStream, exportFileName))
+            when(fileService.createTemporaryFile(zipStream, SpotlightExports.REQUIRED_CHECKS_FILENAME))
                     .thenReturn(new InputStreamResource(new ByteArrayInputStream(zipStream.toByteArray()))
 
                     );

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SubmissionsServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SubmissionsServiceTest.java
@@ -3,10 +3,10 @@ package gov.cabinetoffice.gap.adminbackend.services;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.AmazonSQSException;
 import gov.cabinetoffice.gap.adminbackend.annotations.WithAdminSession;
-import gov.cabinetoffice.gap.adminbackend.constants.SpotlightHeaders;
 import gov.cabinetoffice.gap.adminbackend.dtos.UserV2DTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationAuditDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationFormDTO;
+import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.submission.*;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantExportEntity;
 import gov.cabinetoffice.gap.adminbackend.entities.SchemeEntity;
@@ -23,9 +23,6 @@ import gov.cabinetoffice.gap.adminbackend.repositories.GrantExportRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.SubmissionRepository;
 import gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomGrantExportEntityGenerator;
 import gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomSubmissionGenerator;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,20 +35,18 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import static gov.cabinetoffice.gap.adminbackend.services.SubmissionsService.*;
+import static gov.cabinetoffice.gap.adminbackend.services.SubmissionsService.combineAddressLines;
+import static gov.cabinetoffice.gap.adminbackend.services.SubmissionsService.mandatoryValue;
 import static gov.cabinetoffice.gap.adminbackend.testdata.SubmissionTestData.*;
 import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomSubmissionGenerator.randomSubmission;
 import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomSubmissionGenerator.randomSubmissionDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -85,67 +80,64 @@ class SubmissionsServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
+    @Mock
+    private SchemeService schemeService;
+
+    @Mock
+    private ZipService zipService;
+
     private final List<String> EXPECTED_SPOTLIGHT_ROW = Arrays.asList("GAP-LL-20220927-1", "Some company name",
             "9-10 St Andrew Square", "Edinburgh", "EH2 2AF", "500", "12738494", "Yes", "");
 
     @Nested
     class ExportSpotlightChecksTests {
 
-        private static void assertRowIsAsExpected(Row actualRow, List<String> expectedRow) {
-            assertThat(actualRow.getPhysicalNumberOfCells()).isEqualTo(expectedRow.size());
-            for (int col = 0; col < expectedRow.size(); col++) {
-                assertThat(actualRow.getCell(col).getStringCellValue()).isEqualTo(expectedRow.get(col));
-            }
-        }
-
         @Test
-        void forSingleRowWithGoodData() throws IOException {
+        void exportSpotlightChecksWithGoodData() {
             final ApplicationFormDTO applicationFormDTO = ApplicationFormDTO.builder()
-                    .audit(ApplicationAuditDTO.builder().createdBy(1).build()).build();
+                    .audit(ApplicationAuditDTO.builder().createdBy(1).build()).grantSchemeId(1)
+                    .applicationName("applicationName").build();
             final SubmissionDefinition submissionDefinition = randomSubmissionDefinition(SUBMISSION_DEFINITION).build();
             final Submission submission = RandomSubmissionGenerator.randomSubmission()
                     .status(SubmissionStatus.SUBMITTED)
                     .createdBy(GrantApplicant.builder().id(1).userId(UUID.randomUUID().toString()).build())
                     .definition(submissionDefinition).build();
+            final SchemeDTO schemeDTO = SchemeDTO.builder().schemeId(1).ggisReference("123").build();
 
             when(applicationFormService.retrieveApplicationFormSummary(1, false, false)).thenReturn(applicationFormDTO);
             when(submissionRepository.findByApplicationGrantApplicationIdAndStatus(1, SubmissionStatus.SUBMITTED))
                     .thenReturn(Collections.singletonList(submission));
+            when(schemeService.getSchemeBySchemeId(applicationFormDTO.getGrantSchemeId())).thenReturn(schemeDTO);
             doReturn(EXPECTED_SPOTLIGHT_ROW).when(submissionsService).buildSingleSpotlightRow(submission);
+            when(zipService.createZip(anyList(), anyList(), anyList())).thenReturn(new ByteArrayOutputStream());
 
             ByteArrayOutputStream dataStream = submissionsService.exportSpotlightChecks(1);
 
-            Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(dataStream.toByteArray()));
-            Row headerRow = workbook.getSheetAt(0).getRow(0);
-            assertRowIsAsExpected(headerRow, SpotlightHeaders.SPOTLIGHT_HEADERS);
-            Row dataRow = workbook.getSheetAt(0).getRow(1);
-            assertRowIsAsExpected(dataRow, EXPECTED_SPOTLIGHT_ROW);
+            verify(submissionRepository).findByApplicationGrantApplicationIdAndStatus(1, SubmissionStatus.SUBMITTED);
+            assertThat(dataStream).isNotNull();
         }
 
         @Test
-        void ignoresBadDataRows() throws IOException {
+        void exportSpotlightChecksWithEmptySubmission() {
+
             final ApplicationFormDTO applicationFormDTO = ApplicationFormDTO.builder()
-                    .audit(ApplicationAuditDTO.builder().createdBy(1).build()).build();
+                    .audit(ApplicationAuditDTO.builder().createdBy(1).build()).grantSchemeId(1)
+                    .applicationName("applicationName").build();
+            final Submission submission = randomSubmission().definition(emptySubmissionDefinition()).build();
+            final SchemeDTO schemeDTO = SchemeDTO.builder().schemeId(1).ggisReference("123").build();
+
             when(applicationFormService.retrieveApplicationFormSummary(1, false, false)).thenReturn(applicationFormDTO);
-
-            final SubmissionDefinition goodSubmission = createSubmissionDefinition();
-            final Submission goodSubmissionEntity = randomSubmission().status(SubmissionStatus.SUBMITTED)
-                    .createdBy(GrantApplicant.builder().id(1).userId(UUID.randomUUID().toString()).build())
-                    .gapId("GAP-LL-20221006-1").definition(goodSubmission).build();
-
-            final SubmissionDefinition badSubmission = createSubmissionDefinition();
-            badSubmission.getSections().get(1).getQuestionById("APPLICANT_ORG_NAME").setResponse(null);
-            final Submission badSubmissionEntity = randomSubmission().status(SubmissionStatus.SUBMITTED)
-                    .createdBy(GrantApplicant.builder().id(1).userId(UUID.randomUUID().toString()).build())
-                    .gapId("GAP-LL-20221006-2").definition(badSubmission).build();
-
             when(submissionRepository.findByApplicationGrantApplicationIdAndStatus(1, SubmissionStatus.SUBMITTED))
-                    .thenReturn(List.of(badSubmissionEntity, goodSubmissionEntity));
+                    .thenReturn(Collections.singletonList(submission));
+            when(schemeService.getSchemeBySchemeId(applicationFormDTO.getGrantSchemeId())).thenReturn(schemeDTO);
+            doReturn(EXPECTED_SPOTLIGHT_ROW).when(submissionsService).buildSingleSpotlightRow(submission);
+            when(zipService.createZip(anyList(), anyList(), anyList())).thenReturn(new ByteArrayOutputStream());
 
             ByteArrayOutputStream dataStream = submissionsService.exportSpotlightChecks(1);
 
-            Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(dataStream.toByteArray()));
-            assertThat(workbook.getSheetAt(0).getPhysicalNumberOfRows()).isEqualTo(2);
+            verify(submissionRepository).findByApplicationGrantApplicationIdAndStatus(1, SubmissionStatus.SUBMITTED);
+            assertThat(dataStream).isNotNull();
+
         }
 
         @Test


### PR DESCRIPTION
## Description
Only allows 999 rows per file and when it exceeds this, it creates a new file. All these files are then zipped so that they can be downloaded together.

Updated the required checks download to download a zip file instead of just an .xlsx file to accommodate for multiple files if submissions exceeds 999

Ticket # and link
TMI2-524: https://technologyprogramme.atlassian.net/browse/TMI2-524

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
