### PR TITLE
TMI2-524: check if advert exists before creating a new one

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -94,13 +94,11 @@ public class GrantAdvertService {
                     .status(GrantAdvertStatus.DRAFT).version(version).build();
             return this.grantAdvertRepository.save(grantAdvert);
         }
-        else {
-            final GrantAdvert existingAdvert = grantAdvertRepository.findBySchemeId(grantSchemeId).get();
-            existingAdvert.setGrantAdvertName(name);
-            existingAdvert.setLastUpdatedBy(grantAdmin);
-            existingAdvert.setLastUpdated(Instant.now());
-            return this.grantAdvertRepository.save(existingAdvert);
-        }
+        final GrantAdvert existingAdvert = grantAdvertRepository.findBySchemeId(grantSchemeId).get();
+        existingAdvert.setGrantAdvertName(name);
+        existingAdvert.setLastUpdatedBy(grantAdmin);
+        existingAdvert.setLastUpdated(Instant.now());
+        return this.grantAdvertRepository.save(existingAdvert);
 
     }
 


### PR DESCRIPTION
## Description
The user was able to create multiple adverts for a scheme. Now inside the create method, we check if an advert already exists, if it does, we just update it and only create a new advert if one does not exist

Ticket # and link
TMI2-525: https://technologyprogramme.atlassian.net/browse/TMI2-525

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
