### PR TITLE
fix call to user-service

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
@@ -1,7 +1,8 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
-import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.annotations.LambdasHeaderValidator;
+import gov.cabinetoffice.gap.adminbackend.config.LambdaSecretConfigProperties;
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.UrlDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.submission.LambdaSubmissionDefinition;
@@ -31,7 +32,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,6 +54,8 @@ public class SubmissionsController {
     private final S3Service s3Service;
 
     private final FileService fileService;
+
+    private final LambdaSecretConfigProperties lambdaSecretConfigProperties;
 
     @GetMapping(value = "/spotlight-export/{applicationId}", produces = EXPORT_CONTENT_TYPE)
     public ResponseEntity<InputStreamResource> exportSpotlightChecks(@PathVariable Integer applicationId) {
@@ -108,12 +110,10 @@ public class SubmissionsController {
                     content = @Content(mediaType = "application/json")) })
     @LambdasHeaderValidator
     public ResponseEntity getSubmissionInfo(final @PathVariable @NotNull UUID submissionId,
-            final @PathVariable @NotNull UUID batchExportId,
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
-
+            final @PathVariable @NotNull UUID batchExportId) {
         try {
             final LambdaSubmissionDefinition submission = submissionsService.getSubmissionInfo(submissionId,
-                    batchExportId, authHeader);
+                    batchExportId, lambdaSecretConfigProperties.getSecret());
             return ResponseEntity.ok(submission);
         }
         catch (NotFoundException e) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
@@ -1,7 +1,8 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
-import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
+import gov.cabinetoffice.gap.adminbackend.config.LambdaSecretConfigProperties;
 import gov.cabinetoffice.gap.adminbackend.config.LambdasInterceptor;
+import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.UrlDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.submission.LambdaSubmissionDefinition;
@@ -70,6 +71,9 @@ class SubmissionsControllerTest {
 
     @MockBean
     private SubmissionsService submissionsService;
+
+    @MockBean
+    private LambdaSecretConfigProperties mockLambdaSecretConfigProperties;
 
     @MockBean
     private S3Service s3Service;
@@ -213,6 +217,7 @@ class SubmissionsControllerTest {
         @Test
         void happyPath() throws Exception {
             final LambdaSubmissionDefinition lambdaSubmissionDefinition = LambdaSubmissionDefinition.builder().build();
+            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
             when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
                     .thenReturn(lambdaSubmissionDefinition);
 
@@ -225,6 +230,7 @@ class SubmissionsControllerTest {
 
         @Test
         void unauthorisedPath() throws Exception {
+            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
             when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
                     .thenThrow(new UnauthorizedException());
 
@@ -236,6 +242,7 @@ class SubmissionsControllerTest {
 
         @Test
         void resourceNotFoundPath() throws Exception {
+            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
             when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
                     .thenThrow(new NotFoundException());
 


### PR DESCRIPTION
## Description

in one of the endpoint used by the lambdas, we are calling user service too.

in this call we were passing the same AuthorizationSecret used by the lambda which now is encrypted.

We are now passing the non encrypted authorization value to the user service request(how it was).

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
