### PR TITLE
GAP-2359: Publish/unpublish ads includes time

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/schedulers/GrantAdvertsScheduler.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/schedulers/GrantAdvertsScheduler.java
@@ -29,7 +29,7 @@ public class GrantAdvertsScheduler {
 
     private final GrantAdvertsSchedulerConfigProperties advertsSchedulerConfigProperties;
 
-    @Scheduled(cron = "${grant-adverts-scheduler.cronExpression:0 0 * * * ?}", zone = "UTC")
+    @Scheduled(cron = "${grant-adverts-scheduler.cronExpression:0 0 * * * ?}")
     @SchedulerLock(name = "grantAdverts_publishUnpublishScheduler",
             lockAtMostFor = "${grant-adverts-scheduler.lock.atMostFor:30m}",
             lockAtLeastFor = "${grant-adverts-scheduler.lock.atLeastFor:5m}")

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/schedulers/GrantAdvertsScheduler.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/schedulers/GrantAdvertsScheduler.java
@@ -29,7 +29,7 @@ public class GrantAdvertsScheduler {
 
     private final GrantAdvertsSchedulerConfigProperties advertsSchedulerConfigProperties;
 
-    @Scheduled(cron = "${grant-adverts-scheduler.cronExpression:0 0 0 * * ?}", zone = "UTC")
+    @Scheduled(cron = "${grant-adverts-scheduler.cronExpression:0 0 * * * ?}", zone = "UTC")
     @SchedulerLock(name = "grantAdverts_publishUnpublishScheduler",
             lockAtMostFor = "${grant-adverts-scheduler.lock.atMostFor:30m}",
             lockAtLeastFor = "${grant-adverts-scheduler.lock.atLeastFor:5m}")

--- a/src/main/resources/db/migration/V1_83__scheduled_publishing_include_time.sql
+++ b/src/main/resources/db/migration/V1_83__scheduled_publishing_include_time.sql
@@ -6,16 +6,16 @@ SELECT GRANT_ADVERT_ID AS ID,
     CASE
         WHEN
             STATUS = 'SCHEDULED'
-            AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= (NOW() AT TIME ZONE 'Europe/London')
+            AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= NOW()
         THEN 'PUBLISH'
         WHEN
             STATUS = 'PUBLISHED'
-            AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= ((NOW() AT TIME ZONE 'Europe/London'))
+            AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= NOW()
         THEN 'UNPUBLISH'
     END AS ACTION
 FROM GRANT_ADVERT
 WHERE (
-    STATUS = 'SCHEDULED' AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= (NOW() AT TIME ZONE 'Europe/London')
+    STATUS = 'SCHEDULED' AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= NOW()
 ) OR (
-    STATUS = 'PUBLISHED' AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= ((NOW() AT TIME ZONE 'Europe/London'))
+    STATUS = 'PUBLISHED' AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= NOW()
 );

--- a/src/main/resources/db/migration/V1_83__scheduled_publishing_include_time.sql
+++ b/src/main/resources/db/migration/V1_83__scheduled_publishing_include_time.sql
@@ -1,0 +1,21 @@
+-- Replace view for scheduler
+
+DROP VIEW IF EXISTS ADVERT_SCHEDULER_VIEW;
+CREATE VIEW ADVERT_SCHEDULER_VIEW AS
+SELECT GRANT_ADVERT_ID AS ID,
+    CASE
+        WHEN
+            STATUS = 'SCHEDULED'
+            AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= (NOW() AT TIME ZONE 'Europe/London')
+        THEN 'PUBLISH'
+        WHEN
+            STATUS = 'PUBLISHED'
+            AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= ((NOW() AT TIME ZONE 'Europe/London'))
+        THEN 'UNPUBLISH'
+    END AS ACTION
+FROM GRANT_ADVERT
+WHERE (
+    STATUS = 'SCHEDULED' AND (OPENING_DATE AT TIME ZONE 'Europe/London') <= (NOW() AT TIME ZONE 'Europe/London')
+) OR (
+    STATUS = 'PUBLISHED' AND (CLOSING_DATE AT TIME ZONE 'Europe/London') <= ((NOW() AT TIME ZONE 'Europe/London'))
+);


### PR DESCRIPTION
## Description

Ticket [GAP-2359](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2359)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Refactored DB publishing view to take into account time
- Also treats the timestamp as Europe/London time
- Scheduled job default cron runs hourly
- Removed scheduled job zone as it will use the servers local zone by default (and run hourly regardless)
- Updated scheduled job sandbox cron time AWS secret to also be hourly

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2359]: https://technologyprogramme.atlassian.net/browse/GAP-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ