### PR TITLE
TMI2-549 - Updating table and entities with 'created_by' field

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/FeedbackEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/FeedbackEntity.java
@@ -32,6 +32,9 @@ public class FeedbackEntity {
     @Builder.Default
     private Instant created = Instant.now();
 
+    @Column(name = "created_by", nullable = false)
+    private Integer created_by;
+
     @Column(name = "journey")
     private String journey;
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackService.java
@@ -1,7 +1,9 @@
 package gov.cabinetoffice.gap.adminbackend.services;
 
 import gov.cabinetoffice.gap.adminbackend.entities.FeedbackEntity;
+import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 import gov.cabinetoffice.gap.adminbackend.repositories.FeedbackRepository;
+import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -15,8 +17,9 @@ public class FeedbackService {
 
     public void addFeedback(int satisfactionScore, String userComment, String userJourney) {
         try {
+            AdminSession session = HelperUtils.getAdminSessionForAuthenticatedUser();
             FeedbackEntity feedback = FeedbackEntity.builder().satisfaction(satisfactionScore).comment(userComment)
-                    .journey(userJourney).build();
+                    .journey(userJourney).created_by(session.getGrantAdminId()).build();
             this.feedbackRepository.save(feedback);
         }
         catch (Exception e) {

--- a/src/main/resources/db/migration/V1_88__alter_feedback_table_with_user_id.sql
+++ b/src/main/resources/db/migration/V1_88__alter_feedback_table_with_user_id.sql
@@ -1,0 +1,7 @@
+ALTER TABLE feedback
+ADD COLUMN created_by INTEGER;
+
+UPDATE feedback SET created_by = 1;
+
+ALTER TABLE feedback
+ALTER COLUMN created_by SET NOT NULL;

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackServiceTest.java
@@ -24,6 +24,8 @@ public class FeedbackServiceTest {
 
     public final static Instant SAMPLE_CREATED = Instant.parse(instantExpected);
 
+    public final static Integer SAMPLE_CREATED_BY = 1;
+
     final Clock clock = Clock.fixed(Instant.parse(instantExpected), ZoneId.of("UTC"));
 
     final Instant instant = Instant.now(clock);
@@ -35,22 +37,22 @@ public class FeedbackServiceTest {
     public final static String APPLICATION_JOURNEY = "application";
 
     public static final FeedbackEntity SATISFACTION_ONLY_ENTITY = new FeedbackEntity(null, 1, "", SAMPLE_CREATED,
-            DEFAULT_JOURNEY);
+            SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
     public static final FeedbackEntity COMMENT_ONLY_ENTITY = new FeedbackEntity(null, 0, SAMPLE_COMMENT, SAMPLE_CREATED,
-            DEFAULT_JOURNEY);
+            SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
     public static final FeedbackEntity FEEDBACK_ENTITY = new FeedbackEntity(null, 5, SAMPLE_COMMENT, SAMPLE_CREATED,
-            DEFAULT_JOURNEY);
+            SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
     public static final FeedbackEntity APPLICATION_JOURNEY_ENTITY = new FeedbackEntity(null, 5, SAMPLE_COMMENT,
-            SAMPLE_CREATED, APPLICATION_JOURNEY);
+            SAMPLE_CREATED, SAMPLE_CREATED_BY, APPLICATION_JOURNEY);
 
     public static final FeedbackEntity OUTWITH_LIMIT_ENTITY = new FeedbackEntity(null, 9, SAMPLE_COMMENT,
-            SAMPLE_CREATED, DEFAULT_JOURNEY);
+            SAMPLE_CREATED, SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
     public static final FeedbackEntity EMPTY_COMMENT_ENTITY = new FeedbackEntity(null, 0, "", SAMPLE_CREATED,
-            DEFAULT_JOURNEY);
+            SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
     @Mock
     private FeedbackRepository feedbackRepository;


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-549

Adds a new field created_by field to the Feedback database table that captures who has left comments or satisfaction scores.

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
