### PR TITLE
GAP-2396: Validate max words field in patch question endpoint

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -189,7 +189,6 @@ public class ApplicationFormService {
         }
         violationsSet = this.validator.validate(mappedQuestion);
 
-        // FIXME significant changes needed to refactor the DTO to support an Object for validation
         validateMaxWordsValidationField(questionPatchDto, responseType);
 
         if (!violationsSet.isEmpty()) {
@@ -201,7 +200,7 @@ public class ApplicationFormService {
 
     }
 
-    // FIXME significant changes needed to refactor the DTO to support an Object for validation
+    // TODO GAP-2429: Refactor validation of validation Map to use a DTO with proper validation annotations
     private void validateMaxWordsValidationField(final ApplicationFormQuestionDTO questionPatchDto, final ResponseTypeEnum responseType) {
         if (responseType == ResponseTypeEnum.LongAnswer) {
             final String MAX_WORDS_FIELD = "maxWords";

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -20,12 +20,14 @@ import gov.cabinetoffice.gap.adminbackend.utils.ApplicationFormUtils;
 import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpSession;
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 import java.time.Instant;
@@ -174,21 +176,21 @@ public class ApplicationFormService {
 
     private QuestionAbstractPatchDTO validatePatchQuestion(ApplicationFormQuestionDTO questionPatchDto,
             ResponseTypeEnum responseType) {
-        Set violationsSet;
+        Set<ConstraintViolation<QuestionAbstractPatchDTO>> violationsSet;
         QuestionAbstractPatchDTO mappedQuestion;
 
         // check response type, map to the correct model, and validate
-        // left as switch statement in the event of new question types
-        switch (responseType) {
-            case MultipleSelection, Dropdown, SingleSelection -> {
-                mappedQuestion = this.applicationFormMapper.questionDtoToQuestionOptionsPatch(questionPatchDto);
-                violationsSet = this.validator.validate(mappedQuestion);
-            }
-            default -> {
-                mappedQuestion = this.applicationFormMapper.questionDtoToQuestionGenericPatch(questionPatchDto);
-                violationsSet = this.validator.validate(mappedQuestion);
-            }
+        if (Objects.requireNonNull(responseType) == ResponseTypeEnum.MultipleSelection
+                || responseType == ResponseTypeEnum.Dropdown || responseType == ResponseTypeEnum.SingleSelection) {
+            mappedQuestion = this.applicationFormMapper.questionDtoToQuestionOptionsPatch(questionPatchDto);
         }
+        else {
+            mappedQuestion = this.applicationFormMapper.questionDtoToQuestionGenericPatch(questionPatchDto);
+        }
+        violationsSet = this.validator.validate(mappedQuestion);
+
+        // FIXME significant changes needed to refactor the DTO to support an Object for validation
+        validateMaxWordsValidationField(questionPatchDto, responseType);
 
         if (!violationsSet.isEmpty()) {
             throw new ConstraintViolationException(violationsSet);
@@ -197,6 +199,30 @@ public class ApplicationFormService {
             return mappedQuestion;
         }
 
+    }
+
+    // FIXME significant changes needed to refactor the DTO to support an Object for validation
+    private void validateMaxWordsValidationField(final ApplicationFormQuestionDTO questionPatchDto, final ResponseTypeEnum responseType) {
+        if (responseType == ResponseTypeEnum.LongAnswer) {
+            final String MAX_WORDS_FIELD = "maxWords";
+            if (!questionPatchDto.getValidation().containsKey(MAX_WORDS_FIELD)) {
+                throw new FieldViolationException(MAX_WORDS_FIELD, "Please enter the max words an applicant could enter");
+            }
+            final String maxWordsString = questionPatchDto.getValidation().get("maxWords").toString();
+            if (maxWordsString.isBlank()) {
+                throw new FieldViolationException(MAX_WORDS_FIELD, "Please enter the max words an applicant could enter");
+            }
+            if (!NumberUtils.isCreatable(maxWordsString)) {
+                throw new FieldViolationException(MAX_WORDS_FIELD, "Max words must be a number");
+            }
+            final long maxWords = Long.parseLong(maxWordsString);
+            if (maxWords < 1) {
+                throw new FieldViolationException(MAX_WORDS_FIELD, "Max words must be greater than 0");
+            }
+            if (maxWords > 5000) {
+                throw new FieldViolationException(MAX_WORDS_FIELD, "Max words must be less than 5000");
+            }
+        }
     }
 
     public String addQuestionToApplicationForm(Integer applicationId, String sectionId,


### PR DESCRIPTION
## Description

Ticket [GAP-2396](https://technologyprogramme.atlassian.net/browse/GAP-2396)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Adding hard coded validation for maxWords
- Sadly cant make use of the in built validator as a significant refactor of several core aspects of the app would need to be done to change validation from a Map<String, Object> to a DTO with validation annotations
- Raised https://technologyprogramme.atlassian.net/browse/GAP-2429 for this

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/160b489e-2f87-422f-babe-14e0f5c08eb0


# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.

[GAP-2396]: https://technologyprogramme.atlassian.net/browse/GAP-2396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ