### PR TITLE
Adds roles to user dto

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/UserDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/UserDTO.java
@@ -13,4 +13,6 @@ public class UserDTO {
 
     private String emailAddress;
 
+    private String roles;
+
 }


### PR DESCRIPTION
Changes in this PR:

- Updates UserDto to include roles

This is consumed by apply frontend and uses it to render the nav bar on the admin dashboard if a user has the tech support role

Related PRs:

Other PRs included in this change:

https://github.com/cabinetoffice/gap-find-api-admin/pull/59
https://github.com/cabinetoffice/gap-find-apply-web/pull/311