### PR TITLE
GAP-2447-owner-editor-data-model

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - develop
+      - feature/**
+      - feat/**
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
@@ -1,9 +1,14 @@
 package gov.cabinetoffice.gap.adminbackend.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
+import org.apache.http.conn.scheme.Scheme;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "grant_admin")
@@ -28,5 +33,13 @@ public class GrantAdmin {
     @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id", referencedColumnName = "gap_user_id")
     private GapUser gapUser;
+
+
+
+    @ManyToMany(fetch = FetchType.LAZY, mappedBy = "grantAdmins")
+    @ToString.Exclude
+    @JsonBackReference
+    @Builder.Default
+    private List<SchemeEntity> schemes = new ArrayList<>();
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
@@ -34,8 +34,6 @@ public class GrantAdmin {
     @JoinColumn(name = "user_id", referencedColumnName = "gap_user_id")
     private GapUser gapUser;
 
-
-
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "grantAdmins")
     @ToString.Exclude
     @JsonBackReference

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
@@ -1,10 +1,14 @@
 package gov.cabinetoffice.gap.adminbackend.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 import org.hibernate.Hibernate;
 
 import javax.persistence.*;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -53,6 +57,16 @@ public class SchemeEntity {
     @Column(name = "scheme_contact")
     private String email;
 
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @JoinTable(name = "scheme_permissions",
+            joinColumns = {@JoinColumn(name = "grant_scheme_id", referencedColumnName = "grant_scheme_id")},
+            inverseJoinColumns = {@JoinColumn(name = "grant_admin_id", referencedColumnName = "grant_admin_id")}
+            )
+    @ToString.Exclude
+    @JsonManagedReference
+    @Builder.Default
+    private List<GrantAdmin> grantAdmins = new ArrayList<>();
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -70,4 +84,7 @@ public class SchemeEntity {
         return getClass().hashCode();
     }
 
+    public void addAdmin(final GrantAdmin admin) {
+        this.grantAdmins.add(admin);
+    }
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
@@ -57,7 +57,7 @@ public class SchemeEntity {
     private String email;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-    @JoinTable(name = "scheme_permissions",
+    @JoinTable(name = "scheme_editors",
             joinColumns = {@JoinColumn(name = "grant_scheme_id", referencedColumnName = "grant_scheme_id")},
             inverseJoinColumns = {@JoinColumn(name = "grant_admin_id", referencedColumnName = "grant_admin_id")}
             )

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
@@ -1,6 +1,5 @@
 package gov.cabinetoffice.gap.adminbackend.entities;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 import org.hibernate.Hibernate;

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/security/AuthManager.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/security/AuthManager.java
@@ -96,7 +96,7 @@ public class AuthManager implements AuthenticationManager {
 
         // save new admin to db. This also creates a matching GapUser
         return this.grantAdminRepository
-                .save(new GrantAdmin(null, fundingOrganisation.get(), new GapUser(null, jwtPayload.getSub())));
+                .save(new GrantAdmin(null, fundingOrganisation.get(), new GapUser(null, jwtPayload.getSub()), new ArrayList<>()));
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
@@ -1,6 +1,5 @@
 package gov.cabinetoffice.gap.adminbackend.services;
 
-import com.amazonaws.services.s3.model.Grant;
 import gov.cabinetoffice.gap.adminbackend.config.FeatureFlagsConfigurationProperties;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemePatchDTO;
@@ -72,7 +71,6 @@ public class SchemeService {
                 entity.setVersion(2);
             }
 
-            //find admin and add to join table
             Optional<GrantAdmin> grantAdmin = this.grantAdminRepository.findById(adminSession.getGrantAdminId());
             if (grantAdmin.isPresent()) {
                 entity.addAdmin(grantAdmin.get());

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
@@ -76,7 +76,10 @@ public class SchemeService {
             Optional<GrantAdmin> grantAdmin = this.grantAdminRepository.findById(adminSession.getGrantAdminId());
             if (grantAdmin.isPresent()) {
                 entity.addAdmin(grantAdmin.get());
-                System.out.println("Grant admin found and added to scheme");
+            }
+            else {
+                throw new SchemeEntityException("Something went wrong while creating a new grant scheme: "
+                        + "No grant admin found for id: " + adminSession.getGrantAdminId());
             }
 
             entity = this.schemeRepo.save(entity);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.adminbackend.services;
 
+import com.amazonaws.services.s3.model.Grant;
 import gov.cabinetoffice.gap.adminbackend.config.FeatureFlagsConfigurationProperties;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemePatchDTO;
@@ -10,6 +11,7 @@ import gov.cabinetoffice.gap.adminbackend.enums.SessionObjectEnum;
 import gov.cabinetoffice.gap.adminbackend.exceptions.SchemeEntityException;
 import gov.cabinetoffice.gap.adminbackend.mappers.SchemeMapper;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
+import gov.cabinetoffice.gap.adminbackend.repositories.GrantAdminRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.SchemeRepository;
 import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpSession;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,8 @@ public class SchemeService {
     private final SessionsService sessionsService;
 
     private final UserService userService;
+
+    private final GrantAdminRepository grantAdminRepository;
 
     private final FeatureFlagsConfigurationProperties featureFlagsConfigurationProperties;
 
@@ -66,6 +71,14 @@ public class SchemeService {
             if (featureFlagsConfigurationProperties.isNewMandatoryQuestionsEnabled()) {
                 entity.setVersion(2);
             }
+
+            //find admin and add to join table
+            Optional<GrantAdmin> grantAdmin = this.grantAdminRepository.findById(adminSession.getGrantAdminId());
+            if (grantAdmin.isPresent()) {
+                entity.addAdmin(grantAdmin.get());
+                System.out.println("Grant admin found and added to scheme");
+            }
+
             entity = this.schemeRepo.save(entity);
             this.sessionsService.deleteObjectFromSession(SessionObjectEnum.newScheme, session);
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
@@ -71,14 +71,11 @@ public class SchemeService {
                 entity.setVersion(2);
             }
 
-            Optional<GrantAdmin> grantAdmin = this.grantAdminRepository.findById(adminSession.getGrantAdminId());
-            if (grantAdmin.isPresent()) {
-                entity.addAdmin(grantAdmin.get());
-            }
-            else {
-                throw new SchemeEntityException("Something went wrong while creating a new grant scheme: "
-                        + "No grant admin found for id: " + adminSession.getGrantAdminId());
-            }
+            this.grantAdminRepository.findById(adminSession.getGrantAdminId())
+                    .ifPresentOrElse(
+                            entity::addAdmin,
+                            () -> new SchemeEntityException("Something went wrong while creating a new grant scheme: No grant admin found for id: " + adminSession.getGrantAdminId())
+                    );
 
             entity = this.schemeRepo.save(entity);
             this.sessionsService.deleteObjectFromSession(SessionObjectEnum.newScheme, session);

--- a/src/main/resources/db/migration/V1_95__add_new_scheme_editors_table.sql
+++ b/src/main/resources/db/migration/V1_95__add_new_scheme_editors_table.sql
@@ -1,18 +1,18 @@
--- Table: public.scheme_permissions
+-- Table: public.scheme_editors
 
-DROP TABLE IF EXISTS public.scheme_permissions;
+DROP TABLE IF EXISTS public.scheme_editors;
 
-CREATE TABLE scheme_permissions (
+CREATE TABLE scheme_editors (
 	grant_admin_id integer NOT NULL,
     grant_scheme_id integer NOT NULL,
 	CONSTRAINT admin FOREIGN KEY (grant_admin_id) REFERENCES grant_admin(grant_admin_id) ON DELETE CASCADE,
 	CONSTRAINT scheme FOREIGN KEY (grant_scheme_id) REFERENCES grant_scheme(grant_scheme_id) ON DELETE CASCADE
 );
 
-ALTER TABLE scheme_permissions ADD CONSTRAINT scheme_permissions_pk PRIMARY KEY (grant_admin_id, grant_scheme_id);
-CREATE UNIQUE INDEX scheme_permissions_index ON scheme_permissions(grant_admin_id, grant_scheme_id);
+ALTER TABLE scheme_editors ADD CONSTRAINT scheme_editors_pk PRIMARY KEY (grant_admin_id, grant_scheme_id);
+CREATE UNIQUE INDEX scheme_editors_index ON scheme_editors(grant_admin_id, grant_scheme_id);
 
 -- Migrating all scheme_owners to scheme_permissions as editors
-INSERT INTO scheme_permissions (grant_admin_id, grant_scheme_id)
+INSERT INTO scheme_editors (grant_admin_id, grant_scheme_id)
     SELECT created_by, grant_scheme_id
     FROM grant_scheme;

--- a/src/main/resources/db/migration/V1_95__add_new_scheme_permissions_table.sql
+++ b/src/main/resources/db/migration/V1_95__add_new_scheme_permissions_table.sql
@@ -1,0 +1,13 @@
+-- Table: public.scheme_permissions
+
+-- DROP TABLE IF EXISTS public.scheme_permissions;
+
+CREATE TABLE scheme_permissions (
+	grant_admin_id integer NOT NULL,
+    grant_scheme_id integer NOT NULL
+	CONSTRAINT admin FOREIGN KEY (grant_admin_id) REFERENCES grant_admin(grant_admin_id) ON DELETE CASCADE,
+	CONSTRAINT scheme FOREIGN KEY (grant_scheme_id) REFERENCES grant_scheme(grant_scheme_id) ON DELETE CASCADE
+);
+
+ALTER TABLE scheme_permissions ADD CONSTRAINT unique_scheme_permission UNIQUE (grant_admin_id, grant_scheme_id);
+

--- a/src/main/resources/db/migration/V1_95__add_new_scheme_permissions_table.sql
+++ b/src/main/resources/db/migration/V1_95__add_new_scheme_permissions_table.sql
@@ -1,13 +1,18 @@
 -- Table: public.scheme_permissions
 
--- DROP TABLE IF EXISTS public.scheme_permissions;
+DROP TABLE IF EXISTS public.scheme_permissions;
 
 CREATE TABLE scheme_permissions (
 	grant_admin_id integer NOT NULL,
-    grant_scheme_id integer NOT NULL
+    grant_scheme_id integer NOT NULL,
 	CONSTRAINT admin FOREIGN KEY (grant_admin_id) REFERENCES grant_admin(grant_admin_id) ON DELETE CASCADE,
 	CONSTRAINT scheme FOREIGN KEY (grant_scheme_id) REFERENCES grant_scheme(grant_scheme_id) ON DELETE CASCADE
 );
 
-ALTER TABLE scheme_permissions ADD CONSTRAINT unique_scheme_permission UNIQUE (grant_admin_id, grant_scheme_id);
+ALTER TABLE scheme_permissions ADD CONSTRAINT scheme_permissions_pk PRIMARY KEY (grant_admin_id, grant_scheme_id);
+CREATE UNIQUE INDEX scheme_permissions_index ON scheme_permissions(grant_admin_id, grant_scheme_id);
 
+-- Migrating all scheme_owners to scheme_permissions as editors
+INSERT INTO scheme_permissions (grant_admin_id, grant_scheme_id)
+    SELECT created_by, grant_scheme_id
+    FROM grant_scheme;

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/FeedbackServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
@@ -58,7 +59,7 @@ public class FeedbackServiceTest {
     public static final FeedbackEntity EMPTY_COMMENT_ENTITY = new FeedbackEntity(null, 0, "", SAMPLE_CREATED,
             SAMPLE_CREATED_BY, DEFAULT_JOURNEY);
 
-    private final GrantAdmin SAMPLE_ADMIN = new GrantAdmin(1, null, new GapUser(1, "sub"));
+    private final GrantAdmin SAMPLE_ADMIN = new GrantAdmin(1, null, new GapUser(1, "sub"), new ArrayList<>());
 
     @Mock
     private FeedbackRepository feedbackRepository;

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -41,10 +41,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.time.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static gov.cabinetoffice.gap.adminbackend.testdata.SchemeTestData.SAMPLE_SCHEME_ID;
 import static gov.cabinetoffice.gap.adminbackend.validation.validators.AdvertPageResponseValidator.*;
@@ -819,8 +816,8 @@ class GrantAdvertServiceTest {
         void publishAdvert_successfullyPublishedAdvert() {
 
             final GrantAdvert mockGrantAdvert = GrantAdvert.builder().id(UUID.randomUUID()).scheme(scheme).version(1)
-                    .created(Instant.now()).createdBy(new GrantAdmin(1, null, null)).lastUpdated(Instant.now())
-                    .lastUpdatedBy(new GrantAdmin(1, null, null)).status(GrantAdvertStatus.DRAFT)
+                    .created(Instant.now()).createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).lastUpdated(Instant.now())
+                    .lastUpdatedBy(new GrantAdmin(1, null, null, new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
                     .contentfulEntryId("entry-id").contentfulSlug("contentful-slug")
                     .grantAdvertName("Grant Advert Name").response(response).grantAdvertName("Homelessness Grant")
                     .build();
@@ -901,8 +898,8 @@ class GrantAdvertServiceTest {
         void publishAdvert_updatesExistingAdvert_IfFirstPublishedDateHasBeenSet() {
 
             final GrantAdvert grantAvertInDatabase = GrantAdvert.builder().id(UUID.randomUUID()).scheme(scheme)
-                    .version(1).created(Instant.now()).createdBy(new GrantAdmin(1, null, null))
-                    .lastUpdated(Instant.now()).lastUpdatedBy(new GrantAdmin(1, null, null))
+                    .version(1).created(Instant.now()).createdBy(new GrantAdmin(1, null, null, new ArrayList<>()))
+                    .lastUpdated(Instant.now()).lastUpdatedBy(new GrantAdmin(1, null, null, new ArrayList<>()))
                     .status(GrantAdvertStatus.DRAFT).contentfulEntryId(contentfulAdvertId)
                     .contentfulSlug("contentful-slug").grantAdvertName("Grant Advert Name").response(response)
                     .grantAdvertName("Homelessness Grant")
@@ -965,8 +962,8 @@ class GrantAdvertServiceTest {
         void publishAdvert_AccessDenied() {
             UUID grantAdvertId = UUID.randomUUID();
             final GrantAdvert mockGrantAdvert = GrantAdvert.builder().id(grantAdvertId).scheme(scheme).version(1)
-                    .created(Instant.now()).createdBy(new GrantAdmin(2, null, null)).lastUpdated(Instant.now())
-                    .lastUpdatedBy(new GrantAdmin(2, null, null)).status(GrantAdvertStatus.DRAFT)
+                    .created(Instant.now()).createdBy(new GrantAdmin(2, null, null, new ArrayList<>())).lastUpdated(Instant.now())
+                    .lastUpdatedBy(new GrantAdmin(2, null, null, new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
                     .contentfulEntryId("entry-id").contentfulSlug("contentful-slug")
                     .grantAdvertName("Grant Advert Name").response(response).grantAdvertName("Homelessness Grant")
                     .build();
@@ -984,8 +981,8 @@ class GrantAdvertServiceTest {
         @Test
         void publishAdvertThroughLambda_successfullyPublishedAdvert() {
             final GrantAdvert mockGrantAdvert = GrantAdvert.builder().id(UUID.randomUUID()).scheme(scheme).version(1)
-                    .created(Instant.now()).createdBy(new GrantAdmin(1, null, null)).lastUpdated(Instant.now())
-                    .lastUpdatedBy(new GrantAdmin(1, null, null)).status(GrantAdvertStatus.DRAFT)
+                    .created(Instant.now()).createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).lastUpdated(Instant.now())
+                    .lastUpdatedBy(new GrantAdmin(1, null, null, new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
                     .contentfulEntryId("entry-id").contentfulSlug("contentful-slug")
                     .grantAdvertName("Grant Advert Name").response(response).grantAdvertName("Homelessness Grant")
                     .build();
@@ -1246,7 +1243,7 @@ class GrantAdvertServiceTest {
 
         final GrantAdvert scheduledGrantAdvert = GrantAdvert.builder().id(grantAdvertId).response(response)
                 .status(GrantAdvertStatus.DRAFT).grantAdvertName("Schedule Test Advert")
-                .createdBy(new GrantAdmin(1, null, null)).build();
+                .createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).build();
 
         @Test
         void scheduleGrantAdvert_Success() {
@@ -1273,7 +1270,7 @@ class GrantAdvertServiceTest {
         void scheduleGrantAdvert_AccessDenied() {
             final GrantAdvert scheduledGrantAdvert = GrantAdvert.builder().id(grantAdvertId).response(response)
                     .status(GrantAdvertStatus.DRAFT).grantAdvertName("Schedule Test Advert")
-                    .createdBy(new GrantAdmin(2, null, null)).build();
+                    .createdBy(new GrantAdmin(2, null, null, new ArrayList<>())).build();
 
             when(grantAdvertRepository.findById(grantAdvertId)).thenReturn(Optional.of(scheduledGrantAdvert));
 
@@ -1303,7 +1300,7 @@ class GrantAdvertServiceTest {
 
         final GrantAdvert scheduledGrantAdvert = GrantAdvert.builder().id(grantAdvertId)
                 .status(GrantAdvertStatus.SCHEDULED).grantAdvertName("Scheduled Test Advert")
-                .createdBy(new GrantAdmin(1, null, null)).build();
+                .createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).build();
 
         @Test
         void scheduleGrantAdvert_Success() {
@@ -1324,7 +1321,7 @@ class GrantAdvertServiceTest {
         void scheduleGrantAdvert_AccessDenied() {
             final GrantAdvert scheduledGrantAdvert = GrantAdvert.builder().id(grantAdvertId).response(response)
                     .status(GrantAdvertStatus.SCHEDULED).grantAdvertName("Schedule Test Advert")
-                    .createdBy(new GrantAdmin(2, null, null)).build();
+                    .createdBy(new GrantAdmin(2, null, null, new ArrayList<>())).build();
 
             when(grantAdvertRepository.findById(grantAdvertId)).thenReturn(Optional.of(scheduledGrantAdvert));
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/LoginTestData.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/LoginTestData.java
@@ -4,6 +4,8 @@ import gov.cabinetoffice.gap.adminbackend.entities.FundingOrganisation;
 import gov.cabinetoffice.gap.adminbackend.entities.GapUser;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdmin;
 
+import java.util.ArrayList;
+
 public class LoginTestData {
 
     public final static Integer GAP_USER_ID = 1;
@@ -21,6 +23,6 @@ public class LoginTestData {
 
     public final static GapUser GAP_USER = new GapUser(GAP_USER_ID, GAP_USER_COGNITO_SUBSCRIPTION);
 
-    public final static GrantAdmin GRANT_ADMIN_USER = new GrantAdmin(GRANT_ADMIN_ID, FUNDING_ORGANISATION, GAP_USER);
+    public final static GrantAdmin GRANT_ADMIN_USER = new GrantAdmin(GRANT_ADMIN_ID, FUNDING_ORGANISATION, GAP_USER, new ArrayList<>());
 
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/SchemeTestData.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/SchemeTestData.java
@@ -4,6 +4,7 @@ import gov.cabinetoffice.gap.adminbackend.dtos.errors.FieldErrorsDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemePatchDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemePostDTO;
+import gov.cabinetoffice.gap.adminbackend.entities.GrantAdmin;
 import gov.cabinetoffice.gap.adminbackend.entities.SchemeEntity;
 import gov.cabinetoffice.gap.adminbackend.models.ClassError;
 import gov.cabinetoffice.gap.adminbackend.models.ValidationError;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -72,7 +74,7 @@ public class SchemeTestData {
 
     public final static SchemeEntity SCHEME_ENTITY_EXAMPLE = new SchemeEntity(SAMPLE_SCHEME_ID, SAMPLE_ORGANISATION_ID,
             1, Instant.parse("2022-07-02T15:00:00.00Z"), SAMPLE_USER_ID, Instant.parse("2022-07-02T16:00:00.00Z"),
-            SAMPLE_USER_ID, SAMPLE_GGIS_REFERENCE, SAMPLE_SCHEME_NAME, SAMPLE_SCHEME_CONTACT);
+            SAMPLE_USER_ID, SAMPLE_GGIS_REFERENCE, SAMPLE_SCHEME_NAME, SAMPLE_SCHEME_CONTACT, new ArrayList<>());
 
     public final static List<SchemeEntity> SCHEME_ENTITY_LIST_EXAMPLE = Collections
             .singletonList(SCHEME_ENTITY_EXAMPLE);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/generators/RandomGrantAdvertGenerators.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/generators/RandomGrantAdvertGenerators.java
@@ -10,6 +10,7 @@ import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.adminbackend.models.*;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -18,8 +19,8 @@ public class RandomGrantAdvertGenerators {
     // Grant advert generators
     public static GrantAdvert.GrantAdvertBuilder randomGrantAdvertEntity() {
         return GrantAdvert.builder().id(UUID.randomUUID()).scheme(RandomSchemeGenerator.randomSchemeEntity().build())
-                .version(1).created(Instant.now()).createdBy(new GrantAdmin(1, null, null)).lastUpdated(Instant.now())
-                .lastUpdatedBy(new GrantAdmin(1, null, null)).status(GrantAdvertStatus.DRAFT)
+                .version(1).created(Instant.now()).createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).lastUpdated(Instant.now())
+                .lastUpdatedBy(new GrantAdmin(1, null, null, new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
                 .contentfulEntryId("entry-id").contentfulSlug("contentful-slug").grantAdvertName("Grant Advert Name")
                 .response(randomAdvertResponse().build());
     }


### PR DESCRIPTION
Added join table (scheme_permissions) and additional functionality in SchemeService to add a single admin to this repository.

GAP-2447: https://technologyprogramme.atlassian.net/browse/GAP-2447

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
