### PR TITLE
TMI2-644 get failed grant export count

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportController.java
@@ -15,11 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Log4j2
@@ -77,9 +75,8 @@ public class GrantExportController {
                     content = @Content(mediaType = "application/json")) })
     @LambdasHeaderValidator
     public ResponseEntity getFailedExportsCount(@PathVariable UUID exportId) {
-        final Long count = exportService.getFailedExportsCount(exportId);
+        final Long count = exportService.getExportCountByStatus(exportId, GrantExportStatus.FAILED);
         return ResponseEntity.ok(new FailedExportCountDTO(count));
-
     }
 
     @GetMapping("/{exportId}/remainingCount")
@@ -93,6 +90,18 @@ public class GrantExportController {
     public ResponseEntity getRemainingExportsCount(@PathVariable UUID exportId) {
         final Long count = exportService.getRemainingExportsCount(exportId);
         return ResponseEntity.ok(new OutstandingExportCountDTO(count));
+    }
+
+    @GetMapping("/{exportId}/status/count")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Returned submission exports count for batch id by status",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = OutstandingExportCountDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Required path variables not provided in expected format",
+                    content = @Content(mediaType = "application/json")) })
+    public ResponseEntity getExportCountByStatus(@PathVariable() UUID exportId, @RequestParam @NotNull GrantExportStatus status){
+        final Long count = exportService.getExportCountByStatus(exportId, status);
+        return ResponseEntity.ok(count);
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportController.java
@@ -99,7 +99,7 @@ public class GrantExportController {
                             schema = @Schema(implementation = OutstandingExportCountDTO.class))),
             @ApiResponse(responseCode = "400", description = "Required path variables not provided in expected format",
                     content = @Content(mediaType = "application/json")) })
-    public ResponseEntity getExportCountByStatus(@PathVariable() UUID exportId, @RequestParam @NotNull GrantExportStatus status){
+    public ResponseEntity<Long> getExportCountByStatus(@PathVariable() UUID exportId, @RequestParam @NotNull GrantExportStatus status){
         final Long count = exportService.getExportCountByStatus(exportId, status);
         return ResponseEntity.ok(count);
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantExportService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantExportService.java
@@ -30,9 +30,9 @@ public class GrantExportService {
         return GrantExportListDTO.builder().exportBatchId(exportId).grantExports(grantExportEntityList).build();
     }
 
-    public Long getFailedExportsCount(UUID exportId) {
-        log.info(String.format("Getting failed export count from grant_export table for exportId: %s", exportId));
-        return exportRepository.countByIdExportBatchIdAndStatus(exportId, GrantExportStatus.FAILED);
+    public Long getExportCountByStatus(UUID exportId, GrantExportStatus status) {
+        log.info(String.format("Getting export count for submissions from grant_export table for exportId: %s with status: %s", exportId, status));
+        return exportRepository.countByIdExportBatchIdAndStatus(exportId, status);
     }
 
     public Long getRemainingExportsCount(UUID exportId) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantExportControllerTest.java
@@ -138,7 +138,7 @@ public class GrantExportControllerTest {
 
         @Test
         void successfullyGetFailedExportsCount() throws Exception {
-            when(mockGrantExportService.getFailedExportsCount(any())).thenReturn(mockCount);
+            when(mockGrantExportService.getExportCountByStatus(any(), any())).thenReturn(mockCount);
 
             mockMvc.perform(get("/export-batch/" + mockExportId + "/failedCount").header(HttpHeaders.AUTHORIZATION,
                             LAMBDA_AUTH_HEADER)).andExpect(status().isOk())
@@ -152,10 +152,27 @@ public class GrantExportControllerTest {
 
         @Test
         void unexpectedErrorOccurred() throws Exception {
-            when(mockGrantExportService.getFailedExportsCount(any())).thenThrow(RuntimeException.class);
+            when(mockGrantExportService.getExportCountByStatus(any(), any())).thenThrow(RuntimeException.class);
 
             mockMvc.perform(get("/export-batch/" + mockExportId + "/failedCount").header(HttpHeaders.AUTHORIZATION,
                     LAMBDA_AUTH_HEADER)).andExpect(status().isInternalServerError());
+        }
+
+    }
+
+    @Nested
+    class getExportCountByStatus {
+
+        @Test
+        void successfullyGetExportCountByStatus() throws Exception {
+            final Long expectedResponse = 2L;
+            when(mockGrantExportService.getExportCountByStatus(mockExportId, GrantExportStatus.COMPLETE))
+                    .thenReturn(expectedResponse);
+
+            mockMvc.perform(get("/export-batch/" + mockExportId +"/status/count")
+                            .param("status", String.valueOf(GrantExportStatus.COMPLETE)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(String.valueOf(expectedResponse)));
         }
 
     }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantExportServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantExportServiceTest.java
@@ -115,12 +115,12 @@ public class GrantExportServiceTest {
     }
 
     @Test
-    void getFailedExportsCount() {
+    void getExportCountByStatus() {
         final UUID mockExportId = UUID.randomUUID();
         final long expectedResponse = 2L;
         when(exportRepository.countByIdExportBatchIdAndStatus(mockExportId, GrantExportStatus.FAILED)).thenReturn(expectedResponse);
 
-        final long response = grantExportService.getFailedExportsCount(mockExportId);
+        final long response = grantExportService.getExportCountByStatus(mockExportId, GrantExportStatus.FAILED);
 
         verify(exportRepository).countByIdExportBatchIdAndStatus(mockExportId, GrantExportStatus.FAILED);
         assertThat(response).isEqualTo(expectedResponse);


### PR DESCRIPTION
## Description
Adds an endpoint to get the number of grant exports with a given status
This should also cover this ticket: https://technologyprogramme.atlassian.net/browse/TMI2-638

Ticket # and link
TMI2-644: https://technologyprogramme.atlassian.net/browse/TMI2-644

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
