### PR TITLE
GAP-2481: Fix publishing adverts

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdmin.java
@@ -2,9 +2,7 @@ package gov.cabinetoffice.gap.adminbackend.entities;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
-import org.apache.http.conn.scheme.Scheme;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -38,6 +36,7 @@ public class GrantAdmin {
     @ToString.Exclude
     @JsonBackReference
     @Builder.Default
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private List<SchemeEntity> schemes = new ArrayList<>();
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
@@ -57,7 +57,7 @@ public class SchemeEntity {
     @Column(name = "scheme_contact")
     private String email;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = { CascadeType.MERGE, CascadeType.PERSIST })
     @JoinTable(name = "scheme_editors",
             joinColumns = {@JoinColumn(name = "grant_scheme_id", referencedColumnName = "grant_scheme_id")},
             inverseJoinColumns = {@JoinColumn(name = "grant_admin_id", referencedColumnName = "grant_admin_id")}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/SchemeEntity.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.adminbackend.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 import org.hibernate.Hibernate;
@@ -56,7 +57,7 @@ public class SchemeEntity {
     @Column(name = "scheme_contact")
     private String email;
 
-    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "scheme_editors",
             joinColumns = {@JoinColumn(name = "grant_scheme_id", referencedColumnName = "grant_scheme_id")},
             inverseJoinColumns = {@JoinColumn(name = "grant_admin_id", referencedColumnName = "grant_admin_id")}
@@ -64,6 +65,7 @@ public class SchemeEntity {
     @ToString.Exclude
     @JsonManagedReference
     @Builder.Default
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private List<GrantAdmin> grantAdmins = new ArrayList<>();
 
     @Override


### PR DESCRIPTION
Publishing adverts was actually successfully updating the database, but fell over as the endpoint returns a raw `GrantAdvert` entity. Jackson attempts to serialize its relationship like the schemeEditors (which were lazy loaded, and therefore dont exist) and falls over. We use an annotation: `@JsonIgnoreProperties` to tell jackson to ignore this relationship.

This code didnt break in other places as endpoints should not return raw entities. If this was mapped to a DTO, it would have not fallen over.

https://github.com/cabinetoffice/gap-find-admin-backend/assets/101722961/007c0df0-e973-47c8-a1d5-83611f80bc70

