### PR TITLE
GAP-2432: add lastUpdatedBy email to advert publishing info

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
@@ -156,7 +156,7 @@ public class GrantAdvertController {
                         content = @Content(mediaType = "application/json")),
                 @ApiResponse(responseCode = "400", description = "Bad request body",
                         content = @Content(mediaType = "application/json")) })
-
+    @CheckSchemeOwnership
     public ResponseEntity getPublishInformation(@RequestParam @NotNull final Integer grantSchemeId) {
         GetGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponse = this.grantAdvertService
                     .getGrantAdvertPublishingInformationBySchemeId(grantSchemeId);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
@@ -149,7 +149,7 @@ public class GrantAdvertController {
     @ApiResponses(value = { @ApiResponse(responseCode = "200",
                 description = "Successfully fetched the publishing information of grant advert for query params provided",
                 content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = FullGrantAdvertPublishingInformationResponseDTO.class))),
+                        schema = @Schema(implementation = GetGrantAdvertPublishingInformationResponseDTO.class))),
                 @ApiResponse(responseCode = "403", description = "Insufficient permissions to fetch this grant advert",
                         content = @Content(mediaType = "application/json")),
                 @ApiResponse(responseCode = "404", description = "No grant advert found for scheme id provided",
@@ -158,7 +158,7 @@ public class GrantAdvertController {
                         content = @Content(mediaType = "application/json")) })
 
     public ResponseEntity getPublishInformation(@RequestParam @NotNull final Integer grantSchemeId) {
-            FullGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponse = this.grantAdvertService
+        GetGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponse = this.grantAdvertService
                     .getGrantAdvertPublishingInformationBySchemeId(grantSchemeId);
 
             return ResponseEntity.ok(grantAdvertPublishingInformationResponse);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
@@ -3,12 +3,7 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 import com.contentful.java.cma.model.CMAHttpException;
 import gov.cabinetoffice.gap.adminbackend.annotations.LambdasHeaderValidator;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.FieldErrorsDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.CreateGrantAdvertDto;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.CreateGrantAdvertResponseDto;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertPublishingInformationResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertStatusResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GrantAdvertPagePatchResponseDto;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GrantAdvertPageResponseValidationDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.*;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.mappers.GrantAdvertMapper;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
@@ -152,22 +147,22 @@ public class GrantAdvertController {
     @GetMapping("/publish-information")
     @Operation(summary = "Retrieves the information around publishing a grant advert for query params provided")
     @ApiResponses(value = { @ApiResponse(responseCode = "200",
-            description = "Successfully fetched the publishing information of grant advert for query params provided",
-            content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = GetGrantAdvertPublishingInformationResponseDTO.class))),
-            @ApiResponse(responseCode = "403", description = "Insufficient permissions to fetch this grant advert",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "No grant advert found for scheme id provided",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad request body",
-                    content = @Content(mediaType = "application/json")) })
-    @CheckSchemeOwnership
+                description = "Successfully fetched the publishing information of grant advert for query params provided",
+                content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = FullGrantAdvertPublishingInformationResponseDTO.class))),
+                @ApiResponse(responseCode = "403", description = "Insufficient permissions to fetch this grant advert",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(responseCode = "404", description = "No grant advert found for scheme id provided",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(responseCode = "400", description = "Bad request body",
+                        content = @Content(mediaType = "application/json")) })
+
     public ResponseEntity getPublishInformation(@RequestParam @NotNull final Integer grantSchemeId) {
+            FullGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponse = this.grantAdvertService
+                    .getGrantAdvertPublishingInformationBySchemeId(grantSchemeId);
 
-        GetGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponse = this.grantAdvertService
-                .getGrantAdvertPublishingInformationBySchemeId(grantSchemeId);
+            return ResponseEntity.ok(grantAdvertPublishingInformationResponse);
 
-        return ResponseEntity.ok(grantAdvertPublishingInformationResponse);
     }
 
     @DeleteMapping("/{grantAdvertId}")

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/FullGrantAdvertPublishingInformationResponseDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/FullGrantAdvertPublishingInformationResponseDTO.java
@@ -1,9 +1,0 @@
-package gov.cabinetoffice.gap.adminbackend.dtos.grantadvert;
-
-
-import lombok.Builder;
-
-@Builder
-public record FullGrantAdvertPublishingInformationResponseDTO(GetGrantAdvertPublishingInformationResponseDTO publishingInfo, String lastUpdatedByEmail) {
-
-}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/FullGrantAdvertPublishingInformationResponseDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/FullGrantAdvertPublishingInformationResponseDTO.java
@@ -1,0 +1,9 @@
+package gov.cabinetoffice.gap.adminbackend.dtos.grantadvert;
+
+
+import lombok.Builder;
+
+@Builder
+public record FullGrantAdvertPublishingInformationResponseDTO(GetGrantAdvertPublishingInformationResponseDTO publishingInfo, String lastUpdatedByEmail) {
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
@@ -32,4 +32,6 @@ public class GetGrantAdvertPublishingInformationResponseDTO {
 
     private String contentfulSlug;
 
+    private String lastUpdatedByEmail;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
@@ -34,4 +34,6 @@ public class GetGrantAdvertPublishingInformationResponseDTO {
 
     private String lastUpdatedByEmail;
 
+    private Instant lastUpdated;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/mappers/GrantAdvertMapper.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/mappers/GrantAdvertMapper.java
@@ -34,6 +34,7 @@ public interface GrantAdvertMapper {
 
     @Mapping(target = "grantAdvertId", source = "id")
     @Mapping(target = "grantAdvertStatus", source = "status")
+    @Mapping(target = "lastUpdatedByEmail", ignore = true)
     GetGrantAdvertPublishingInformationResponseDTO grantAdvertPublishInformationResponseDtoFromGrantAdvert(
             GrantAdvert grantAdvert);
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -502,7 +502,7 @@ public class GrantAdvertService {
         return LocalDateTime.parse(dateStr, formatter).toString();
     }
 
-    public FullGrantAdvertPublishingInformationResponseDTO getGrantAdvertPublishingInformationBySchemeId(
+    public GetGrantAdvertPublishingInformationResponseDTO getGrantAdvertPublishingInformationBySchemeId(
             Integer grantSchemeId) {
         GrantAdvert grantAdvert = grantAdvertRepository.findBySchemeId(grantSchemeId).orElseThrow(
                 () -> new NotFoundException("Grant Advert for Scheme with id " + grantSchemeId + " does not exist"));
@@ -514,8 +514,9 @@ public class GrantAdvertService {
 
         String emailAddress = userService.getEmailAddressForSub(adminSub);
 
-        return FullGrantAdvertPublishingInformationResponseDTO.builder()
-                .publishingInfo(publishingInfo).lastUpdatedByEmail(emailAddress).build();
+        publishingInfo.setLastUpdatedByEmail(emailAddress);
+
+        return publishingInfo;
     }
 
     public GetGrantAdvertStatusResponseDTO getGrantAdvertStatusBySchemeId(Integer grantSchemeId) {

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -9,10 +9,7 @@ import com.contentful.java.cma.model.CMAEntry;
 import com.contentful.java.cma.model.rich.CMARichDocument;
 import gov.cabinetoffice.gap.adminbackend.config.ContentfulConfigProperties;
 import gov.cabinetoffice.gap.adminbackend.config.FeatureFlagsConfigurationProperties;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertPageResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertPublishingInformationResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertStatusResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GrantAdvertPageResponseValidationDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.*;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdmin;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.entities.SchemeEntity;
@@ -70,6 +67,8 @@ public class GrantAdvertService {
     private final CMAClient contentfulManagementClient;
 
     private final CDAClient contentfulDeliveryClient;
+
+    private final UserService userService;
 
     private final WebClient.Builder webClientBuilder;
 
@@ -503,12 +502,20 @@ public class GrantAdvertService {
         return LocalDateTime.parse(dateStr, formatter).toString();
     }
 
-    public GetGrantAdvertPublishingInformationResponseDTO getGrantAdvertPublishingInformationBySchemeId(
+    public FullGrantAdvertPublishingInformationResponseDTO getGrantAdvertPublishingInformationBySchemeId(
             Integer grantSchemeId) {
         GrantAdvert grantAdvert = grantAdvertRepository.findBySchemeId(grantSchemeId).orElseThrow(
                 () -> new NotFoundException("Grant Advert for Scheme with id " + grantSchemeId + " does not exist"));
 
-        return this.grantAdvertMapper.grantAdvertPublishInformationResponseDtoFromGrantAdvert(grantAdvert);
+        GetGrantAdvertPublishingInformationResponseDTO publishingInfo = this.grantAdvertMapper
+                .grantAdvertPublishInformationResponseDtoFromGrantAdvert(grantAdvert);
+
+        String adminSub = grantAdvert.getLastUpdatedBy().getGapUser().getUserSub();
+
+        String emailAddress = userService.getEmailAddressForSub(adminSub);
+
+        return FullGrantAdvertPublishingInformationResponseDTO.builder()
+                .publishingInfo(publishingInfo).lastUpdatedByEmail(emailAddress).build();
     }
 
     public GetGrantAdvertStatusResponseDTO getGrantAdvertStatusBySchemeId(Integer grantSchemeId) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -8,6 +8,8 @@ import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertPageResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
+import gov.cabinetoffice.gap.adminbackend.mappers.GrantAdvertMapperImpl;
+import gov.cabinetoffice.gap.adminbackend.mappers.ValidationErrorMapperImpl;
 import gov.cabinetoffice.gap.adminbackend.models.GrantAdvertPageResponse;
 import gov.cabinetoffice.gap.adminbackend.models.GrantAdvertQuestionResponse;
 import gov.cabinetoffice.gap.adminbackend.security.interceptors.AuthorizationHeaderInterceptor;
@@ -64,7 +66,11 @@ class GrantAdvertControllerTest {
     @MockBean
     private GrantAdvertService grantAdvertService;
 
+    @SpyBean
+    private GrantAdvertMapperImpl grantAdvertMapper;
 
+    @SpyBean
+    private ValidationErrorMapperImpl validationErrorMapper;
 
     @MockBean
     private EventLogService eventLogService;

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -3,10 +3,7 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 import com.contentful.java.cma.model.CMAHttpException;
 import gov.cabinetoffice.gap.adminbackend.annotations.WithAdminSession;
 import gov.cabinetoffice.gap.adminbackend.config.LambdasInterceptor;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.CreateGrantAdvertDto;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertPublishingInformationResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertStatusResponseDTO;
-import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GrantAdvertPageResponseValidationDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.*;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertPageResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
@@ -459,11 +456,14 @@ class GrantAdvertControllerTest {
         @Test
         void getAdvertPublishingInformation_GrantAdvertPublishingInformationReturned() throws Exception {
             String contentfulSlug = "dummy-contentful-slug";
-            GetGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponseDTO = GetGrantAdvertPublishingInformationResponseDTO
+            GetGrantAdvertPublishingInformationResponseDTO publishingInfo = GetGrantAdvertPublishingInformationResponseDTO
                     .builder().grantAdvertId(grantAdvertId).grantAdvertStatus(grantAdvertStatus)
                     .contentfulSlug(contentfulSlug).unpublishedDate(unpublishedDate)
                     .firstPublishedDate(firstPublishedDate).lastPublishedDate(lastPublishedDate)
                     .closingDate(closingDate).openingDate(openingDate).build();
+
+            FullGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponseDTO = FullGrantAdvertPublishingInformationResponseDTO.builder().publishingInfo(
+                    publishingInfo).lastUpdatedByEmail("some-email").build();
 
             when(grantAdvertService.getGrantAdvertPublishingInformationBySchemeId(grantSchemeId))
                     .thenReturn(grantAdvertPublishingInformationResponseDTO);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -8,8 +8,6 @@ import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertPageResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
-import gov.cabinetoffice.gap.adminbackend.mappers.GrantAdvertMapperImpl;
-import gov.cabinetoffice.gap.adminbackend.mappers.ValidationErrorMapperImpl;
 import gov.cabinetoffice.gap.adminbackend.models.GrantAdvertPageResponse;
 import gov.cabinetoffice.gap.adminbackend.models.GrantAdvertQuestionResponse;
 import gov.cabinetoffice.gap.adminbackend.security.interceptors.AuthorizationHeaderInterceptor;
@@ -66,11 +64,7 @@ class GrantAdvertControllerTest {
     @MockBean
     private GrantAdvertService grantAdvertService;
 
-    @SpyBean
-    private GrantAdvertMapperImpl grantAdvertMapper;
 
-    @SpyBean
-    private ValidationErrorMapperImpl validationErrorMapper;
 
     @MockBean
     private EventLogService eventLogService;
@@ -462,15 +456,14 @@ class GrantAdvertControllerTest {
                     .firstPublishedDate(firstPublishedDate).lastPublishedDate(lastPublishedDate)
                     .closingDate(closingDate).openingDate(openingDate).build();
 
-            FullGrantAdvertPublishingInformationResponseDTO grantAdvertPublishingInformationResponseDTO = FullGrantAdvertPublishingInformationResponseDTO.builder().publishingInfo(
-                    publishingInfo).lastUpdatedByEmail("some-email").build();
+
 
             when(grantAdvertService.getGrantAdvertPublishingInformationBySchemeId(grantSchemeId))
-                    .thenReturn(grantAdvertPublishingInformationResponseDTO);
+                    .thenReturn(publishingInfo);
 
             mockMvc.perform(get("/grant-advert/publish-information").param("grantSchemeId", grantSchemeId.toString()))
                     .andExpect(status().isOk())
-                    .andExpect(content().string(HelperUtils.asJsonString(grantAdvertPublishingInformationResponseDTO)))
+                    .andExpect(content().string(HelperUtils.asJsonString(publishingInfo)))
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         }
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -466,6 +466,7 @@ class GrantAdvertControllerTest {
                     .contentfulSlug(contentfulSlug).unpublishedDate(unpublishedDate)
                     .firstPublishedDate(firstPublishedDate).lastPublishedDate(lastPublishedDate)
                     .lastUpdatedByEmail("an-email")
+                    .lastUpdated(lastPublishedDate)
                     .closingDate(closingDate).openingDate(openingDate).build();
 
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -15,6 +15,7 @@ import gov.cabinetoffice.gap.adminbackend.models.GrantAdvertQuestionResponse;
 import gov.cabinetoffice.gap.adminbackend.security.interceptors.AuthorizationHeaderInterceptor;
 import gov.cabinetoffice.gap.adminbackend.services.EventLogService;
 import gov.cabinetoffice.gap.adminbackend.services.GrantAdvertService;
+import gov.cabinetoffice.gap.adminbackend.services.UserService;
 import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,9 @@ class GrantAdvertControllerTest {
 
     @MockBean
     private Validator validator;
+    
+    @MockBean
+    private UserService userService;
 
     @MockBean
     @Qualifier("submissionExportAndScheduledPublishingLambdasInterceptor")
@@ -132,6 +136,7 @@ class GrantAdvertControllerTest {
         String questionId = "grantShortDescription";
 
         String expectedResponse = "This is a description";
+
 
         GrantAdvertPageResponse samplePage = GrantAdvertPageResponse.builder()
                 .status(GrantAdvertPageResponseStatus.IN_PROGRESS)
@@ -460,8 +465,11 @@ class GrantAdvertControllerTest {
                     .builder().grantAdvertId(grantAdvertId).grantAdvertStatus(grantAdvertStatus)
                     .contentfulSlug(contentfulSlug).unpublishedDate(unpublishedDate)
                     .firstPublishedDate(firstPublishedDate).lastPublishedDate(lastPublishedDate)
+                    .lastUpdatedByEmail("an-email")
                     .closingDate(closingDate).openingDate(openingDate).build();
 
+
+            when(userService.getEmailAddressForSub(any())).thenReturn("an-email");
 
 
             when(grantAdvertService.getGrantAdvertPublishingInformationBySchemeId(grantSchemeId))

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -1129,18 +1129,18 @@ class GrantAdvertServiceTest {
 
             when(userService.getEmailAddressForSub(any())).thenReturn(testEmailAddress);
 
-            FullGrantAdvertPublishingInformationResponseDTO actualOutput = grantAdvertService
+            GetGrantAdvertPublishingInformationResponseDTO actualOutput = grantAdvertService
                     .getGrantAdvertPublishingInformationBySchemeId(SAMPLE_SCHEME_ID);
 
-            assertThat(actualOutput.publishingInfo().getGrantAdvertId()).isEqualTo(grantAdvert.getId());
-            assertThat(actualOutput.publishingInfo().getGrantAdvertStatus()).isEqualTo(grantAdvert.getStatus());
-            assertThat(actualOutput.publishingInfo().getContentfulSlug()).isEqualTo(grantAdvert.getContentfulSlug());
-            assertThat(actualOutput.publishingInfo().getFirstPublishedDate()).isEqualTo(grantAdvert.getFirstPublishedDate());
-            assertThat(actualOutput.publishingInfo().getClosingDate()).isEqualTo(grantAdvert.getClosingDate());
-            assertThat(actualOutput.publishingInfo().getOpeningDate()).isEqualTo(grantAdvert.getOpeningDate());
-            assertThat(actualOutput.publishingInfo().getUnpublishedDate()).isEqualTo(grantAdvert.getUnpublishedDate());
-            assertThat(actualOutput.publishingInfo().getLastPublishedDate()).isEqualTo(grantAdvert.getLastPublishedDate());
-            assertThat(actualOutput.lastUpdatedByEmail()).isEqualTo(testEmailAddress);
+            assertThat(actualOutput.getGrantAdvertId()).isEqualTo(grantAdvert.getId());
+            assertThat(actualOutput.getGrantAdvertStatus()).isEqualTo(grantAdvert.getStatus());
+            assertThat(actualOutput.getContentfulSlug()).isEqualTo(grantAdvert.getContentfulSlug());
+            assertThat(actualOutput.getFirstPublishedDate()).isEqualTo(grantAdvert.getFirstPublishedDate());
+            assertThat(actualOutput.getClosingDate()).isEqualTo(grantAdvert.getClosingDate());
+            assertThat(actualOutput.getOpeningDate()).isEqualTo(grantAdvert.getOpeningDate());
+            assertThat(actualOutput.getUnpublishedDate()).isEqualTo(grantAdvert.getUnpublishedDate());
+            assertThat(actualOutput.getLastPublishedDate()).isEqualTo(grantAdvert.getLastPublishedDate());
+            assertThat(actualOutput.getLastUpdatedByEmail()).isEqualTo(testEmailAddress);
 
             verify(grantAdvertMapper).grantAdvertPublishInformationResponseDtoFromGrantAdvert(grantAdvert);
         }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/generators/RandomGrantAdvertGenerators.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/generators/RandomGrantAdvertGenerators.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.adminbackend.testdata.generators;
 
 import gov.cabinetoffice.gap.adminbackend.dtos.grantadvert.GetGrantAdvertPageResponseDTO;
+import gov.cabinetoffice.gap.adminbackend.entities.GapUser;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdmin;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdvert;
 import gov.cabinetoffice.gap.adminbackend.enums.AdvertDefinitionQuestionResponseType;
@@ -20,7 +21,7 @@ public class RandomGrantAdvertGenerators {
     public static GrantAdvert.GrantAdvertBuilder randomGrantAdvertEntity() {
         return GrantAdvert.builder().id(UUID.randomUUID()).scheme(RandomSchemeGenerator.randomSchemeEntity().build())
                 .version(1).created(Instant.now()).createdBy(new GrantAdmin(1, null, null, new ArrayList<>())).lastUpdated(Instant.now())
-                .lastUpdatedBy(new GrantAdmin(1, null, null, new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
+                .lastUpdatedBy(new GrantAdmin(1, null, GapUser.builder().userSub("sub").build(), new ArrayList<>())).status(GrantAdvertStatus.DRAFT)
                 .contentfulEntryId("entry-id").contentfulSlug("contentful-slug").grantAdvertName("Grant Advert Name")
                 .response(randomAdvertResponse().build());
     }


### PR DESCRIPTION
## Description

Ticket # and link

Adds lastUpdatedBy field to publishing info DTO

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2432

related pr: https://github.com/cabinetoffice/gap-find-apply-web/pull/358

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
