### PR TITLE
Use createdBy during isOwner check

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/SchemeRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/SchemeRepository.java
@@ -19,6 +19,6 @@ public interface SchemeRepository extends JpaRepository<SchemeEntity, Integer> {
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     List<SchemeEntity> findByCreatedBy(Integer createdBy);
 
-    boolean existsByIdAndGrantAdminsId(Integer schemeId, Integer grantAdminId);
+    boolean existsByIdAndCreatedBy(Integer schemeId, Integer grantAdminId);
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeEditorService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeEditorService.java
@@ -34,7 +34,7 @@ public class SchemeEditorService {
     private final WebClient.Builder webClientBuilder;
 
     public Boolean doesAdminOwnScheme(Integer schemeId, Integer adminId) {
-        return schemeRepo.existsByIdAndGrantAdminsId(schemeId, adminId);
+        return schemeRepo.existsByIdAndCreatedBy(schemeId, adminId);
     }
 
     public List<SchemeEditorsDTO> getEditorsFromSchemeId(Integer schemeId, String authHeader) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeEditorServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeEditorServiceTest.java
@@ -63,7 +63,7 @@ public class SchemeEditorServiceTest {
     public void testDoesAdminOwnScheme() {
         Integer schemeId = 1;
         Integer adminId = 1;
-        Mockito.when(schemeRepository.existsByIdAndGrantAdminsId(schemeId, adminId)).thenReturn(Boolean.TRUE);
+        Mockito.when(schemeRepository.existsByIdAndCreatedBy(schemeId, adminId)).thenReturn(Boolean.TRUE);
 
         boolean result = schemeEditorService.doesAdminOwnScheme(schemeId, adminId);
         Assertions.assertTrue(result);
@@ -73,7 +73,7 @@ public class SchemeEditorServiceTest {
     public void testDoesAdminOwnScheme_returnsFalse() {
         Integer schemeId = 1;
         Integer adminId = 1;
-        Mockito.when(schemeRepository.existsByIdAndGrantAdminsId(schemeId, adminId)).thenReturn(Boolean.FALSE);
+        Mockito.when(schemeRepository.existsByIdAndCreatedBy(schemeId, adminId)).thenReturn(Boolean.FALSE);
 
         boolean result = schemeEditorService.doesAdminOwnScheme(schemeId, adminId);
         Assertions.assertFalse(result);


### PR DESCRIPTION
## Description

Ticket # and link

Bugfix - use `createdBy` field during isOwner check within SchemeEditorsService

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
