### PR TITLE
GAP 2443 updates to admin dash

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/schemes/OwnedAndEditableSchemesDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/schemes/OwnedAndEditableSchemesDto.java
@@ -1,0 +1,7 @@
+package gov.cabinetoffice.gap.adminbackend.dtos.schemes;
+
+
+import java.util.List;
+
+public record OwnedAndEditableSchemesDto(List<SchemeDTO> ownedSchemes, List<SchemeDTO> editableSchemes) {
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/mappers/SchemeMapper.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/mappers/SchemeMapper.java
@@ -45,25 +45,24 @@ public abstract class SchemeMapper {
         schemeDTO.createdDate( schemeEntity.getCreatedDate() );
         schemeDTO.createdBy( schemeEntity.getCreatedBy() );
 
-        // if last updated is null then return created date + created by.
         setLastUpdatedByValues(schemeEntity, schemeDTO);
 
         return schemeDTO.build();
     }
 
     private void setLastUpdatedByValues(SchemeEntity schemeEntity, SchemeDTO.SchemeDTOBuilder schemeDTO) {
-        final boolean isLastUpdatedBySet = schemeEntity.getLastUpdatedBy() != null;
-        final int lastUpdatedBy  = isLastUpdatedBySet ? schemeEntity.getLastUpdatedBy() : schemeEntity.getCreatedBy();
-        final String lastUpdatedByEmail = userService.getGrantAdminById(lastUpdatedBy)
-                .map(admin -> {
-                    final String sub = admin.getGapUser().getUserSub();
-                    return userService.getEmailAddressForSub(sub);
-                })
-                .orElse(UserService.EMPTY_EMAIL_VALUE); // Should literally never end up in here but would rather display a blank value than throw an error
-        final Instant lastUpdatedDate = isLastUpdatedBySet ? schemeEntity.getLastUpdated() : schemeEntity.getCreatedDate();
+        final boolean isLastUpdatedBySet = schemeEntity.getLastUpdatedBy() != null && schemeEntity.getLastUpdated() != null;
+        if (isLastUpdatedBySet) {
+            final String lastUpdatedByEmail = userService.getGrantAdminById(schemeEntity.getLastUpdatedBy())
+                    .map(admin -> {
+                        final String sub = admin.getGapUser().getUserSub();
+                        return userService.getEmailAddressForSub(sub);
+                    })
+                    .orElse(UserService.EMPTY_EMAIL_VALUE); // Should literally never end up in here but would rather display a blank value than throw an error
 
-        schemeDTO.lastUpdatedBy(lastUpdatedByEmail);
-        schemeDTO.lastUpdatedDate(lastUpdatedDate);
+            schemeDTO.lastUpdatedBy(lastUpdatedByEmail);
+            schemeDTO.lastUpdatedDate(schemeEntity.getLastUpdated());
+        }
     }
 
     public abstract List<SchemeDTO> schemeEntityListtoDtoList(List<SchemeEntity> schemeEntityList);

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/SchemeRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/SchemeRepository.java
@@ -23,4 +23,8 @@ public interface SchemeRepository extends JpaRepository<SchemeEntity, Integer> {
     @PreAuthorize("hasRole('ADMIN')")
     boolean existsByIdAndCreatedBy(Integer schemeId, Integer grantAdminId);
 
+    List<SchemeEntity> findByCreatedByOrderByCreatedDateDesc(Integer grantAdminId, Pageable pagination);
+    List<SchemeEntity> findByCreatedByOrderByCreatedDateDesc(Integer grantAdminId);
+    List<SchemeEntity> findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(Integer createdBy, Integer editorId, Pageable pagination);
+    List<SchemeEntity> findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(Integer createdBy, Integer editorId);
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/SchemeService.java
@@ -169,4 +169,40 @@ public class SchemeService {
         scheme.setFunderId(grantAdmin.getFunder().getId());
         this.schemeRepo.save(scheme);
     }
+
+    public List<SchemeDTO> getPaginatedOwnedSchemes(Pageable pagination) {
+        final AdminSession adminSession = HelperUtils.getAdminSessionForAuthenticatedUser();
+        final int grantAdminId = adminSession.getGrantAdminId();
+        final List<SchemeEntity> schemes = this.schemeRepo
+                    .findByCreatedByOrderByCreatedDateDesc(grantAdminId, pagination);
+
+        return this.schemeMapper.schemeEntityListtoDtoList(schemes);
+    }
+
+    public List<SchemeDTO> getOwnedSchemes() {
+        final AdminSession adminSession = HelperUtils.getAdminSessionForAuthenticatedUser();
+        final int grantAdminId = adminSession.getGrantAdminId();
+        final List<SchemeEntity> schemes = this.schemeRepo
+                .findByCreatedByOrderByCreatedDateDesc(grantAdminId);
+
+        return this.schemeMapper.schemeEntityListtoDtoList(schemes);
+    }
+
+    public List<SchemeDTO> getPaginatedEditableSchemes(Pageable pagination) {
+        final AdminSession adminSession = HelperUtils.getAdminSessionForAuthenticatedUser();
+        final int grantAdminId = adminSession.getGrantAdminId();
+        final List<SchemeEntity> schemes = this.schemeRepo
+                .findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(grantAdminId, grantAdminId, pagination);
+
+        return this.schemeMapper.schemeEntityListtoDtoList(schemes);
+    }
+
+    public List<SchemeDTO> getEditableSchemes() {
+        final AdminSession adminSession = HelperUtils.getAdminSessionForAuthenticatedUser();
+        final int grantAdminId = adminSession.getGrantAdminId();
+        final List<SchemeEntity> schemes = this.schemeRepo
+                .findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(grantAdminId, grantAdminId);
+
+        return this.schemeMapper.schemeEntityListtoDtoList(schemes);
+    }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SchemeControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SchemeControllerTest.java
@@ -3,6 +3,8 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 import gov.cabinetoffice.gap.adminbackend.config.UserServiceConfig;
 import gov.cabinetoffice.gap.adminbackend.dtos.CheckNewAdminEmailDto;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.GenericErrorDTO;
+import gov.cabinetoffice.gap.adminbackend.dtos.schemes.OwnedAndEditableSchemesDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemeDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.schemes.SchemePostDTO;
 import gov.cabinetoffice.gap.adminbackend.entities.FundingOrganisation;
 import gov.cabinetoffice.gap.adminbackend.entities.GrantAdmin;
@@ -25,6 +27,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +37,7 @@ import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_FORM_ENTITY;
@@ -437,4 +441,37 @@ class SchemeControllerTest {
                 .andExpect(content().string("{\"error\":{\"message\":\"\"}}"));
     }
 
+    @Test
+    void getOwnedAndEditableSchemes_ReturnsPaginatedSchemes() throws Exception {
+
+        final SchemeDTO ownedScheme = SchemeDTO.builder().build();
+        final List<SchemeDTO> ownedSchemes = List.of(ownedScheme);
+
+        final SchemeDTO editableScheme = SchemeDTO.builder().build();
+        final List<SchemeDTO> editableSchemes = List.of(editableScheme);
+
+        when(schemeService.getPaginatedOwnedSchemes(any())).thenReturn(ownedSchemes);
+        when(schemeService.getPaginatedEditableSchemes(any())).thenReturn(editableSchemes);
+
+        mockMvc.perform(get("/schemes/editable?paginate=true"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(HelperUtils.asJsonString(new OwnedAndEditableSchemesDto(ownedSchemes, editableSchemes))));
+    }
+
+    @Test
+    void getOwnedAndEditableSchemes_ReturnsUnPaginatedSchemes() throws Exception {
+
+        final SchemeDTO ownedScheme = SchemeDTO.builder().build();
+        final List<SchemeDTO> ownedSchemes = List.of(ownedScheme);
+
+        final SchemeDTO editableScheme = SchemeDTO.builder().build();
+        final List<SchemeDTO> editableSchemes = List.of(editableScheme);
+
+        when(schemeService.getOwnedSchemes()).thenReturn(ownedSchemes);
+        when(schemeService.getEditableSchemes()).thenReturn(editableSchemes);
+
+        mockMvc.perform(get("/schemes/editable"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(HelperUtils.asJsonString(new OwnedAndEditableSchemesDto(ownedSchemes, editableSchemes))));
+    }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/mappers/SchemeMapperTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/mappers/SchemeMapperTest.java
@@ -140,8 +140,8 @@ class SchemeMapperTest {
 
         final SchemeDTO schemeDto = schemeMapper.schemeEntityToDto(scheme);
 
-        assertThat(schemeDto.getLastUpdatedBy()).isEqualTo(updatedBy);
-        assertThat(schemeDto.getLastUpdatedDate()).isEqualTo(scheme.getCreatedDate());
+        assertThat(schemeDto.getLastUpdatedBy()).isNull();
+        assertThat(schemeDto.getLastUpdatedDate()).isNull();
 
         assertCommonFields(schemeDto, scheme);
     }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeServiceTest.java
@@ -391,4 +391,59 @@ class SchemeServiceTest {
 
         assertThat(methodResponse).isEqualTo(schemeDtos);
     }
+
+    @Test
+    void getOwnedSchemes_Success() {
+        final SchemeEntity scheme = SchemeEntity.builder().build();
+        final List<SchemeEntity> schemes = List.of(scheme);
+        final SchemeDTO schemeDto = SchemeDTO.builder().build();
+        final List<SchemeDTO> schemeDtos = List.of(schemeDto);
+
+        when(schemeRepository.findByCreatedByOrderByCreatedDateDesc(1))
+                .thenReturn(schemes);
+
+        when(schemeMapper.schemeEntityListtoDtoList(schemes))
+                .thenReturn(schemeDtos);
+
+        final List<SchemeDTO> methodResponse = schemeService.getOwnedSchemes();
+
+        assertThat(methodResponse).isEqualTo(schemeDtos);
+    }
+
+    @Test
+    void getPaginatedEditableSchemes_Success() {
+        final Pageable pagination = Pageable.ofSize(2);
+        final SchemeEntity scheme = SchemeEntity.builder().build();
+        final List<SchemeEntity> schemes = List.of(scheme);
+        final SchemeDTO schemeDto = SchemeDTO.builder().build();
+        final List<SchemeDTO> schemeDtos = List.of(schemeDto);
+
+        when(schemeRepository.findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(1, 1, pagination))
+                .thenReturn(schemes);
+
+        when(schemeMapper.schemeEntityListtoDtoList(schemes))
+                .thenReturn(schemeDtos);
+
+        final List<SchemeDTO> methodResponse = schemeService.getPaginatedEditableSchemes(pagination);
+
+        assertThat(methodResponse).isEqualTo(schemeDtos);
+    }
+
+    @Test
+    void getEditableSchemes_Success() {
+        final SchemeEntity scheme = SchemeEntity.builder().build();
+        final List<SchemeEntity> schemes = List.of(scheme);
+        final SchemeDTO schemeDto = SchemeDTO.builder().build();
+        final List<SchemeDTO> schemeDtos = List.of(schemeDto);
+
+        when(schemeRepository.findByCreatedByNotAndGrantAdminsIdOrderByCreatedDateDesc(1, 1))
+                .thenReturn(schemes);
+
+        when(schemeMapper.schemeEntityListtoDtoList(schemes))
+                .thenReturn(schemeDtos);
+
+        final List<SchemeDTO> methodResponse = schemeService.getEditableSchemes();
+
+        assertThat(methodResponse).isEqualTo(schemeDtos);
+    }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/SchemeServiceTest.java
@@ -14,12 +14,14 @@ import gov.cabinetoffice.gap.adminbackend.mappers.SchemeMapper;
 import gov.cabinetoffice.gap.adminbackend.repositories.GrantAdminRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.SchemeRepository;
 import gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomSchemeGenerator;
+import org.apache.http.conn.scheme.Scheme;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -369,5 +371,24 @@ class SchemeServiceTest {
                 () -> SchemeServiceTest.this.schemeService.patchCreatedBy(GrantAdmin.builder().id(1).build(), 1))
                 .isInstanceOf(SchemeEntityException.class).hasMessage(
                         "Update grant ownership failed: Something went wrong while trying to find scheme with id: 1");
+    }
+
+    @Test
+    void getPaginatedOwnedSchemes_Success() {
+        final Pageable pagination = Pageable.ofSize(2);
+        final SchemeEntity scheme = SchemeEntity.builder().build();
+        final List<SchemeEntity> schemes = List.of(scheme);
+        final SchemeDTO schemeDto = SchemeDTO.builder().build();
+        final List<SchemeDTO> schemeDtos = List.of(schemeDto);
+
+        when(schemeRepository.findByCreatedByOrderByCreatedDateDesc(1, pagination))
+                .thenReturn(schemes);
+
+        when(schemeMapper.schemeEntityListtoDtoList(schemes))
+                .thenReturn(schemeDtos);
+
+        final List<SchemeDTO> methodResponse = schemeService.getPaginatedOwnedSchemes(pagination);
+
+        assertThat(methodResponse).isEqualTo(schemeDtos);
     }
 }


### PR DESCRIPTION
- Added an endpoint to fetch owned and editable grants in two separate lists 
- Updated the `SchemeMapper` to only return a last updated by date if it is not null. Previously was returning the created date in this instance. 
- 