### PR TITLE
TMI@-616: get application form status

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormController.java
@@ -249,6 +249,14 @@ public class ApplicationFormController {
         return ResponseEntity.ok(email);
     }
 
+    @GetMapping("/{applicationId}/status")
+    @CheckSchemeOwnership
+    public ResponseEntity<String> getApplicationStatus(@PathVariable final Integer applicationId) {
+        final ApplicationStatusEnum applicationStatus = applicationFormService.getApplicationStatus(applicationId);
+        return ResponseEntity.ok(applicationStatus.toString());
+    }
+
+
     private void logApplicationEvent(EventType eventType, String sessionId, String applicationId) {
 
         try {

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -20,7 +20,6 @@ import gov.cabinetoffice.gap.adminbackend.repositories.SchemeRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.TemplateApplicationFormRepository;
 import gov.cabinetoffice.gap.adminbackend.utils.ApplicationFormUtils;
 import gov.cabinetoffice.gap.adminbackend.utils.HelperUtils;
-import static java.lang.Integer.parseInt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -35,6 +34,8 @@ import javax.validation.Validator;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.*;
+
+import static java.lang.Integer.parseInt;
 
 @Service
 @RequiredArgsConstructor
@@ -381,6 +382,11 @@ public class ApplicationFormService {
         return this.applicationFormRepository.findById(applicationId)
                 .orElseThrow(() -> new NotFoundException("Application with id " + applicationId + " does not exist"))
                 .getLastUpdateBy();
+    }
 
+    public ApplicationStatusEnum getApplicationStatus(Integer applicationId) {
+        return this.applicationFormRepository.findById(applicationId)
+                .orElseThrow(() -> new NotFoundException("Application with id " + applicationId + " does not exist"))
+                .getApplicationStatus();
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormControllerTest.java
@@ -34,34 +34,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_ADVERT_ID;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_FORM_DTO;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_FORM_EXISTS_DTO_MULTIPLE_PROPS;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_FORM_EXISTS_DTO_SINGLE_PROP;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_ID;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_NAME;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_POST_FORM_DTO;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_APPLICATION_RESPONSE_SUCCESS;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_CLASS_ERROR_NO_PROPS_PROVIDED;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_PATCH_APPLICATION_DTO;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_PATCH_UPDATED_APPLICATION_DTO;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.SAMPLE_SCHEME_ID;
+import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.*;
 import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators.randomApplicationFormFound;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -462,5 +440,22 @@ class ApplicationFormControllerTest {
                 thenReturn(Optional.of(ApplicationFormEntity.builder().lastUpdateBy(1).build()));
         when(userService.getGrantAdminById(anyInt())).thenReturn(Optional.empty());
         this.mockMvc.perform(get("/application-forms/1/lastUpdated/email")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getApplicationStatus() throws Exception {
+        when(applicationFormService.getApplicationStatus(anyInt())).thenReturn(ApplicationStatusEnum.PUBLISHED);
+
+        this.mockMvc.perform(get("/application-forms/1/status"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(ApplicationStatusEnum.PUBLISHED.toString()));
+    }
+
+    @Test
+    void getApplicationStatusNotFoundException() throws Exception {
+        when(applicationFormService.getApplicationStatus(anyInt())).thenThrow(new NotFoundException());
+
+        this.mockMvc.perform(get("/application-forms/1/status"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormServiceTest.java
@@ -14,22 +14,14 @@ import gov.cabinetoffice.gap.adminbackend.mappers.ApplicationFormMapper;
 import gov.cabinetoffice.gap.adminbackend.mappers.ApplicationFormMapperImpl;
 import gov.cabinetoffice.gap.adminbackend.repositories.ApplicationFormRepository;
 import gov.cabinetoffice.gap.adminbackend.repositories.TemplateApplicationFormRepository;
-import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.*;
-import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators.randomApplicationFormEntity;
-import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators.randomApplicationFormFound;
 import gov.cabinetoffice.gap.adminbackend.testdata.projectionimpls.TestApplicationFormsFoundView;
 import gov.cabinetoffice.gap.adminbackend.utils.ApplicationFormUtils;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Fail.fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
-import static org.mockito.Mockito.*;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import javax.persistence.EntityNotFoundException;
@@ -38,6 +30,14 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.*;
+
+import static gov.cabinetoffice.gap.adminbackend.testdata.ApplicationFormTestData.*;
+import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators.randomApplicationFormEntity;
+import static gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators.randomApplicationFormFound;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Fail.fail;
+import static org.mockito.Mockito.*;
 
 @SpringJUnitConfig
 @WithAdminSession
@@ -837,6 +837,39 @@ class ApplicationFormServiceTest {
                     .updateQuestionOrder(applicationId, sectionId, questionId, increment)).isInstanceOf(NotFoundException.class)
                     .hasMessage("Application with id " + applicationId
                             + " does not exist or insufficient permissions");
+
+        }
+
+    }
+
+    @Nested
+    class getApplicationStatus {
+
+        @Test
+        void getApplicationStatusSuccessful() {
+            final Integer applicationId =1;
+            final ApplicationStatusEnum expectedStatus = ApplicationStatusEnum.PUBLISHED;
+            ApplicationFormEntity applicationForm = ApplicationFormEntity.builder()
+                    .grantApplicationId(applicationId)
+                    .applicationStatus(expectedStatus)
+                    .build();
+
+            when(applicationFormRepository.findById(anyInt())).thenReturn(Optional.of(applicationForm));
+
+            final ApplicationStatusEnum response = applicationFormService.getApplicationStatus(applicationId);
+
+            verify(applicationFormRepository).findById(applicationId);
+            assertThat(response).isEqualTo(expectedStatus);
+
+        }
+
+        @Test
+        void getApplicationStatusNotFoundException() {
+            final Integer applicationId = 1;
+            when(applicationFormRepository.findById(anyInt())).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> applicationFormService.getApplicationStatus(applicationId))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("Application with id " + applicationId + " does not exist");
 
         }
 


### PR DESCRIPTION
## Description
Adds an endpoint to get application form status to be used in the frontend to redirect admins who try to edit an application form with PUBLISHED status

Ticket # and link
TMI2-616: https://technologyprogramme.atlassian.net/browse/TMI2-616

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
