### PR TITLE
GAP-2454/GAP-2457: Multiple Editors with Section Title

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
@@ -3,6 +3,7 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 import gov.cabinetoffice.gap.adminbackend.dtos.GenericPostResponseDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationFormSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationSectionOrderPatchDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.application.PatchSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.PostSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.GenericErrorDTO;
 import gov.cabinetoffice.gap.adminbackend.enums.SectionStatusEnum;
@@ -176,12 +177,12 @@ public class ApplicationFormSectionsController {
     @CheckSchemeOwnership
     public ResponseEntity<Void> updateSectionTitle(final HttpServletRequest request,
             final @PathVariable Integer applicationId, final @PathVariable String sectionId,
-            final @RequestBody @Validated PostSectionDTO sectionDTO) {
+            final @RequestBody @Validated PatchSectionDTO sectionDTO) {
         if (Objects.equals(sectionId, "ELIGIBILITY") || Objects.equals(sectionId, "ESSENTIAL")) {
             return new ResponseEntity(new GenericErrorDTO("You cannot update the title of a non-custom section"),
                     HttpStatus.BAD_REQUEST);
         }
-        this.applicationFormSectionService.updateSectionTitle(applicationId, sectionId, sectionDTO.getSectionTitle());
+        this.applicationFormSectionService.updateSectionTitle(applicationId, sectionId, sectionDTO.getSectionTitle(), sectionDTO.getVersion());
         logApplicationUpdatedEvent(request.getSession().getId(), applicationId);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ControllerExceptionHandler.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ControllerExceptionHandler.java
@@ -5,6 +5,7 @@ import gov.cabinetoffice.gap.adminbackend.annotations.NotAllNull;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.ClassErrorsDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.FieldErrorsDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.GenericErrorDTO;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.FieldViolationException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.UnauthorizedException;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -112,6 +114,14 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
         return handleExceptionInternal(ex, new GenericErrorDTO("Contentful exception."), new HttpHeaders(),
                 HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    @ExceptionHandler(value = { ObjectOptimisticLockingFailureException.class })
+    protected ResponseEntity<Object> handleConflict(ObjectOptimisticLockingFailureException ex, WebRequest request) {
+        log.error(ex.getMessage(), ex);
+
+        return handleExceptionInternal(ex, new GenericErrorDTO("MULTIPLE_EDITORS"), new HttpHeaders(),
+                HttpStatus.CONFLICT, request);
     }
 
     /**

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/PatchSectionDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/PatchSectionDTO.java
@@ -1,0 +1,29 @@
+package gov.cabinetoffice.gap.adminbackend.dtos.application;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PatchSectionDTO {
+
+    // following regex allows empty string, letters, spaces, apostrophes, commas, and
+    // hyphens.
+    // the reason it allows empty string is so that only the @NotBlank error message will
+    // return on empty string
+    @Pattern(regexp = "^(?![\\s\\S])|^[a-zA-Z\\s',-]+$",
+            message = "Section name must only use letters a to z, and special characters such as hyphens, spaces and apostrophes")
+    @NotBlank(message = "Enter a section name")
+    @Size(max = 250, message = "Your Section name must be 250 characters or less.")
+    private String sectionTitle;
+
+    private Integer version;
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/ApplicationFormEntity.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/ApplicationFormEntity.java
@@ -28,8 +28,9 @@ public class ApplicationFormEntity extends BaseEntity {
     @Column(name = "grant_scheme_id")
     private Integer grantSchemeId;
 
+    @Version
     @Column(name = "version")
-    private Integer version;
+    protected Integer version;
 
     @Column(name = "created")
     private Instant created;

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/exceptions/ConflictException.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/exceptions/ConflictException.java
@@ -1,0 +1,24 @@
+package gov.cabinetoffice.gap.adminbackend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+
+    public ConflictException() {
+    }
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConflictException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
@@ -7,6 +7,7 @@ import gov.cabinetoffice.gap.adminbackend.entities.ApplicationFormEntity;
 import gov.cabinetoffice.gap.adminbackend.enums.SectionStatusEnum;
 import gov.cabinetoffice.gap.adminbackend.exceptions.FieldViolationException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 import gov.cabinetoffice.gap.adminbackend.repositories.ApplicationFormRepository;
 import gov.cabinetoffice.gap.adminbackend.utils.ApplicationFormUtils;
@@ -90,7 +91,7 @@ public class ApplicationFormSectionService {
         this.applicationFormRepository.save(applicationForm);
     }
 
-    public void updateSectionTitle(final Integer applicationId, final String sectionId, final String title) {
+    public void updateSectionTitle(final Integer applicationId, final String sectionId, final String title, final Integer version) {
 
         ApplicationFormEntity applicationForm = this.applicationFormRepository.findById(applicationId)
                 .orElseThrow(() -> new NotFoundException("Application with id " + applicationId + " does not exist"));
@@ -100,6 +101,8 @@ public class ApplicationFormSectionService {
         verifyUniqueSectionName(applicationForm, title);
 
         applicationDefinition.getSectionById(sectionId).setSectionTitle(title.replace("\"", ""));
+
+        ApplicationFormUtils.verifyApplicationFormVersion(version, applicationForm);
         ApplicationFormUtils.updateAuditDetailsAfterFormChange(applicationForm, false);
         this.applicationFormRepository.save(applicationForm);
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
@@ -96,13 +96,14 @@ public class ApplicationFormSectionService {
         ApplicationFormEntity applicationForm = this.applicationFormRepository.findById(applicationId)
                 .orElseThrow(() -> new NotFoundException("Application with id " + applicationId + " does not exist"));
 
+        ApplicationFormUtils.verifyApplicationFormVersion(version, applicationForm);
+
         ApplicationDefinitionDTO applicationDefinition = applicationForm.getDefinition();
 
         verifyUniqueSectionName(applicationForm, title);
 
         applicationDefinition.getSectionById(sectionId).setSectionTitle(title.replace("\"", ""));
 
-        ApplicationFormUtils.verifyApplicationFormVersion(version, applicationForm);
         ApplicationFormUtils.updateAuditDetailsAfterFormChange(applicationForm, false);
         this.applicationFormRepository.save(applicationForm);
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
@@ -1,9 +1,11 @@
 package gov.cabinetoffice.gap.adminbackend.utils;
 
 import gov.cabinetoffice.gap.adminbackend.entities.ApplicationFormEntity;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 
 import java.time.Instant;
+import java.util.Objects;
 
 public class ApplicationFormUtils {
 
@@ -14,6 +16,12 @@ public class ApplicationFormUtils {
             applicationFormEntity.setLastUpdateBy(session.getGrantAdminId());
         }
         applicationFormEntity.setVersion(applicationFormEntity.getVersion() + 1);
+    }
+
+    public static void verifyApplicationFormVersion(Integer version, ApplicationFormEntity applicationFormEntity) {
+        if (!Objects.equals(version, applicationFormEntity.getVersion())) {
+            throw new ConflictException("MULTIPLE_EDITORS");
+        }
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
@@ -15,7 +15,6 @@ public class ApplicationFormUtils {
             AdminSession session = HelperUtils.getAdminSessionForAuthenticatedUser();
             applicationFormEntity.setLastUpdateBy(session.getGrantAdminId());
         }
-        applicationFormEntity.setVersion(applicationFormEntity.getVersion() + 1);
     }
 
     public static void verifyApplicationFormVersion(Integer version, ApplicationFormEntity applicationFormEntity) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
@@ -2,6 +2,7 @@ package gov.cabinetoffice.gap.adminbackend.controllers;
 
 import gov.cabinetoffice.gap.adminbackend.annotations.WithAdminSession;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationSectionOrderPatchDto;
+import gov.cabinetoffice.gap.adminbackend.dtos.application.PatchSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.application.PostSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.FieldErrorsDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.errors.GenericErrorDTO;
@@ -280,22 +281,21 @@ class ApplicationFormSectionsControllerTest {
 
         @Test
         void updateSectionTitle__HappyPath() throws Exception {
-
-            String sectionTitle = "sectionTitle";
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
 
             doNothing().when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
-                    .updateSectionTitle(any(), any(), any());
+                    .updateSectionTitle(any(), any(), any(), any());
 
             ApplicationFormSectionsControllerTest.this.mockMvc.perform(
                     patch("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "CUSTOM_SECTION" + "/title")
-                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(sectionTitle)))
+                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(patchSectionDTO)))
                     .andExpect(status().isOk());
         }
 
         @Test
         void updateSectionTitle__BadRequest__NoPayload() throws Exception {
             doNothing().when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
-                    .updateSectionTitle(any(), any(), any());
+                    .updateSectionTitle(any(), any(), any(), any());
 
             ApplicationFormSectionsControllerTest.this.mockMvc
                     .perform(patch(
@@ -307,7 +307,7 @@ class ApplicationFormSectionsControllerTest {
         void updateSectionTitle__BadRequest__NotACustomSection() throws Exception {
             String sectionTitle = "sectionTitle";
             doNothing().when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
-                    .updateSectionTitle(any(), any(), any());
+                    .updateSectionTitle(any(), any(), any(), any());
 
             ApplicationFormSectionsControllerTest.this.mockMvc.perform(
                     patch("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ELIGIBILITY" + "/title")
@@ -317,27 +317,27 @@ class ApplicationFormSectionsControllerTest {
 
         @Test
         void updateSectionTitle__NotFound() throws Exception {
-            String sectionTitle = "sectionTitle";
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
             doThrow(NotFoundException.class)
                     .when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
-                    .updateSectionTitle(any(), any(), any());
+                    .updateSectionTitle(any(), any(), any(), any());
 
             ApplicationFormSectionsControllerTest.this.mockMvc.perform(
                     patch("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "CUSTOM_SECTION" + "/title")
-                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(sectionTitle)))
+                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(patchSectionDTO)))
                     .andExpect(status().isNotFound());
         }
 
         @Test
         void updateSectionTitle__AccessDenied() throws Exception {
-            String sectionTitle = "sectionTitle";
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
             doThrow(AccessDeniedException.class)
                     .when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
-                    .updateSectionTitle(any(), any(), any());
+                    .updateSectionTitle(any(), any(), any(), any());
 
             ApplicationFormSectionsControllerTest.this.mockMvc.perform(
                     patch("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "CUSTOM_SECTION" + "/title")
-                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(sectionTitle)))
+                            .contentType(MediaType.APPLICATION_JSON).content(HelperUtils.asJsonString(patchSectionDTO)))
                     .andExpect(status().isForbidden());
         }
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtilsTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtilsTest.java
@@ -53,7 +53,6 @@ class ApplicationFormUtilsTest {
 
         assertThat(applicationForm.getLastUpdated()).isAfter(fiveSecondsAgo);
         assertEquals(session.getGrantAdminId(), applicationForm.getLastUpdateBy());
-        assertEquals(Integer.valueOf(2), applicationForm.getVersion());
     }
 
     @Test
@@ -66,7 +65,6 @@ class ApplicationFormUtilsTest {
         ApplicationFormUtils.updateAuditDetailsAfterFormChange(applicationForm, true);
 
         assertThat(applicationForm.getLastUpdated()).isAfter(fiveSecondsAgo);
-        assertEquals(Integer.valueOf(2), applicationForm.getVersion());
     }
 
     @Test

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtilsTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtilsTest.java
@@ -2,6 +2,7 @@ package gov.cabinetoffice.gap.adminbackend.utils;
 
 import gov.cabinetoffice.gap.adminbackend.annotations.WithAdminSession;
 import gov.cabinetoffice.gap.adminbackend.entities.ApplicationFormEntity;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 import gov.cabinetoffice.gap.adminbackend.testdata.generators.RandomApplicationFormGenerators;
 import org.junit.Before;
@@ -14,6 +15,8 @@ import org.mockito.Mockito;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -54,7 +57,7 @@ class ApplicationFormUtilsTest {
     }
 
     @Test
-    void doesntCallSetLastUpdateByWhenIsLambdaEqualsTrue() {
+    void updateAuditDetailsAfterFormChange_DoesNotCallSetLastUpdateByWhenIsLambdaEqualsTrue() {
         Instant fiveSecondsAgo = Instant.now().minusSeconds(5);
         Integer version = 1;
         ApplicationFormEntity applicationForm = Mockito.spy(RandomApplicationFormGenerators
@@ -64,6 +67,33 @@ class ApplicationFormUtilsTest {
 
         assertThat(applicationForm.getLastUpdated()).isAfter(fiveSecondsAgo);
         assertEquals(Integer.valueOf(2), applicationForm.getVersion());
+    }
+
+    @Test
+    void verifyApplicationFormVersion_DoesNotThrowErrorWhenVersionMatches() {
+        Integer version = 2;
+        ApplicationFormEntity applicationForm = RandomApplicationFormGenerators
+                .randomApplicationFormEntity()
+                .version(version)
+                .build();
+
+        assertDoesNotThrow(() ->
+                ApplicationFormUtils.verifyApplicationFormVersion(version, applicationForm)
+        );
+    }
+
+    @Test
+    void verifyApplicationFormVersion_ThrowsErrorWhenVersionDoesNotMatch() {
+        Integer version = 2;
+        ApplicationFormEntity applicationForm = RandomApplicationFormGenerators
+                .randomApplicationFormEntity()
+                .version(version)
+                .build();
+
+        assertThrows(
+                ConflictException.class,
+                () -> ApplicationFormUtils.verifyApplicationFormVersion(1, applicationForm)
+        );
     }
 
 }


### PR DESCRIPTION
## Description

[GAP-2454](https://technologyprogramme.atlassian.net/browse/GAP-2454)
with [GAP-2457](https://technologyprogramme.atlassian.net/browse/GAP-2457) to prove it works

Off the back of https://github.com/cabinetoffice/gap-find-admin-backend/pull/232 this is a new PR which does not include the renaming of version to revision to prevent conflicts

Summary of the changes and the related issue. List any dependencies that are required for this change:
https://github.com/cabinetoffice/gap-find-apply-web/pull/374

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2454]: https://technologyprogramme.atlassian.net/browse/GAP-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAP-2457]: https://technologyprogramme.atlassian.net/browse/GAP-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ