### PR TITLE
GAP-2460 | Multiple editors - delete section

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
@@ -104,7 +104,7 @@ public class ApplicationFormSectionsController {
         }
     }
 
-    @DeleteMapping("/{sectionId}/{version}")
+    @DeleteMapping("/{sectionId}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Section deleted successfully.",
                     content = @Content(mediaType = "application/json")),
@@ -116,7 +116,7 @@ public class ApplicationFormSectionsController {
                     content = @Content(mediaType = "application/json")) })
     @CheckSchemeOwnership
     public ResponseEntity deleteSection(final HttpServletRequest request, @PathVariable Integer applicationId,
-            @PathVariable String sectionId, @PathVariable Integer version) {
+            @PathVariable String sectionId, @RequestParam Integer version) {
         try {
             // don't allow admins to delete mandatory sections
             if (Objects.equals(sectionId, "ELIGIBILITY") || Objects.equals(sectionId, "ESSENTIAL")) {

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsController.java
@@ -104,7 +104,7 @@ public class ApplicationFormSectionsController {
         }
     }
 
-    @DeleteMapping("/{sectionId}")
+    @DeleteMapping("/{sectionId}/{version}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Section deleted successfully.",
                     content = @Content(mediaType = "application/json")),
@@ -116,7 +116,7 @@ public class ApplicationFormSectionsController {
                     content = @Content(mediaType = "application/json")) })
     @CheckSchemeOwnership
     public ResponseEntity deleteSection(final HttpServletRequest request, @PathVariable Integer applicationId,
-            @PathVariable String sectionId) {
+            @PathVariable String sectionId, @PathVariable Integer version) {
         try {
             // don't allow admins to delete mandatory sections
             if (Objects.equals(sectionId, "ELIGIBILITY") || Objects.equals(sectionId, "ESSENTIAL")) {
@@ -124,7 +124,7 @@ public class ApplicationFormSectionsController {
                         HttpStatus.BAD_REQUEST);
             }
 
-            this.applicationFormSectionService.deleteSectionFromApplication(applicationId, sectionId);
+            this.applicationFormSectionService.deleteSectionFromApplication(applicationId, sectionId, version);
 
             logApplicationUpdatedEvent(request.getRequestedSessionId(), applicationId);
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormSectionService.java
@@ -61,10 +61,12 @@ public class ApplicationFormSectionService {
         return newSection.getSectionId();
     }
 
-    public void deleteSectionFromApplication(Integer applicationId, String sectionId) {
+    public void deleteSectionFromApplication(Integer applicationId, String sectionId, Integer version) {
         ApplicationFormEntity applicationForm = this.applicationFormRepository.findById(applicationId)
                 .orElseThrow(() -> new NotFoundException(
                         "Application with id " + applicationId + " does not exist or insufficient permissions"));
+
+        ApplicationFormUtils.verifyApplicationFormVersion(version, applicationForm);
 
         boolean sectionDeleted = applicationForm.getDefinition().getSections()
                 .removeIf(section -> Objects.equals(section.getSectionId(), sectionId));

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
@@ -194,16 +194,16 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionHappyPathTest() throws Exception {
 
         doNothing().when(this.applicationFormSectionService).deleteSectionFromApplication(SAMPLE_APPLICATION_ID,
-                SAMPLE_SECTION_ID);
+                SAMPLE_SECTION_ID, 1);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
                 .andExpect(status().isOk());
     }
 
     @Test
     void deleteSectionDeleteMandatorySectionTest() throws Exception {
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL"))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL" + "/" + 1))
                 .andExpect(status().isBadRequest());
     }
 
@@ -211,9 +211,9 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionDoesntExistTest() throws Exception {
 
         doThrow(new NotFoundException("Error message")).when(this.applicationFormSectionService)
-                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID);
+                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, 1);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
                 .andExpect(status().isNotFound())
                 .andExpect(content().json(HelperUtils.asJsonString(new GenericErrorDTO("Error message"))));
     }
@@ -222,9 +222,9 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionAccessDeniedTest() throws Exception {
 
         doThrow(new AccessDeniedException("Error message")).when(this.applicationFormSectionService)
-                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID);
+                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, 1);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
                 .andExpect(status().isForbidden()).andExpect(content().string(""));
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
@@ -194,16 +194,16 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionHappyPathTest() throws Exception {
 
         doNothing().when(this.applicationFormSectionService).deleteSectionFromApplication(SAMPLE_APPLICATION_ID,
-                SAMPLE_SECTION_ID, 1);
+                SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
                 .andExpect(status().isOk());
     }
 
     @Test
     void deleteSectionDeleteMandatorySectionTest() throws Exception {
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL" + "/" + 1))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL" + "/" + SAMPLE_VERSION))
                 .andExpect(status().isBadRequest());
     }
 
@@ -211,9 +211,9 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionDoesntExistTest() throws Exception {
 
         doThrow(new NotFoundException("Error message")).when(this.applicationFormSectionService)
-                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, 1);
+                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
                 .andExpect(status().isNotFound())
                 .andExpect(content().json(HelperUtils.asJsonString(new GenericErrorDTO("Error message"))));
     }
@@ -222,9 +222,9 @@ class ApplicationFormSectionsControllerTest {
     void deleteSectionAccessDeniedTest() throws Exception {
 
         doThrow(new AccessDeniedException("Error message")).when(this.applicationFormSectionService)
-                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, 1);
+                .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + 1))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
                 .andExpect(status().isForbidden()).andExpect(content().string(""));
     }
 
@@ -281,7 +281,7 @@ class ApplicationFormSectionsControllerTest {
 
         @Test
         void updateSectionTitle__HappyPath() throws Exception {
-            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(SAMPLE_VERSION).build();
 
             doNothing().when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
                     .updateSectionTitle(any(), any(), any(), any());
@@ -317,7 +317,7 @@ class ApplicationFormSectionsControllerTest {
 
         @Test
         void updateSectionTitle__NotFound() throws Exception {
-            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(SAMPLE_VERSION).build();
             doThrow(NotFoundException.class)
                     .when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
                     .updateSectionTitle(any(), any(), any(), any());
@@ -330,7 +330,7 @@ class ApplicationFormSectionsControllerTest {
 
         @Test
         void updateSectionTitle__AccessDenied() throws Exception {
-            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(1).build();
+            PatchSectionDTO patchSectionDTO = new PatchSectionDTO().builder().sectionTitle("sectionTitle").version(SAMPLE_VERSION).build();
             doThrow(AccessDeniedException.class)
                     .when(ApplicationFormSectionsControllerTest.this.applicationFormSectionService)
                     .updateSectionTitle(any(), any(), any(), any());

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormSectionsControllerTest.java
@@ -196,14 +196,14 @@ class ApplicationFormSectionsControllerTest {
         doNothing().when(this.applicationFormSectionService).deleteSectionFromApplication(SAMPLE_APPLICATION_ID,
                 SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "?version=" + SAMPLE_VERSION))
                 .andExpect(status().isOk());
     }
 
     @Test
     void deleteSectionDeleteMandatorySectionTest() throws Exception {
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL" + "/" + SAMPLE_VERSION))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + "ESSENTIAL" + "?version=" + SAMPLE_VERSION))
                 .andExpect(status().isBadRequest());
     }
 
@@ -213,7 +213,7 @@ class ApplicationFormSectionsControllerTest {
         doThrow(new NotFoundException("Error message")).when(this.applicationFormSectionService)
                 .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "?version=" + SAMPLE_VERSION))
                 .andExpect(status().isNotFound())
                 .andExpect(content().json(HelperUtils.asJsonString(new GenericErrorDTO("Error message"))));
     }
@@ -224,7 +224,7 @@ class ApplicationFormSectionsControllerTest {
         doThrow(new AccessDeniedException("Error message")).when(this.applicationFormSectionService)
                 .deleteSectionFromApplication(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID, SAMPLE_VERSION);
 
-        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "/" + SAMPLE_VERSION))
+        this.mockMvc.perform(delete("/application-forms/" + SAMPLE_APPLICATION_ID + "/sections/" + SAMPLE_SECTION_ID + "?version=" + SAMPLE_VERSION))
                 .andExpect(status().isForbidden()).andExpect(content().string(""));
     }
 


### PR DESCRIPTION
## Description

[GAP-2460](https://technologyprogramme.atlassian.net/browse/GAP-2460)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Multiple editors - prevent deleting application section if version is outdated
https://github.com/cabinetoffice/gap-find-apply-web/pull/383

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2460]: https://technologyprogramme.atlassian.net/browse/GAP-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ