### PR TITLE
GAP-2458: Multiple Editors - edit question

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/ApplicationFormQuestionDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/ApplicationFormQuestionDTO.java
@@ -39,4 +39,6 @@ public class ApplicationFormQuestionDTO {
 
     private List<String> options;
 
+    private Integer version;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/questions/QuestionSessionDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/application/questions/QuestionSessionDTO.java
@@ -26,4 +26,6 @@ public class QuestionSessionDTO {
     @NotEmpty(message = "Select whether the question is optional or not")
     private String optional;
 
+    private Integer version;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -147,6 +147,8 @@ public class ApplicationFormService {
             ApplicationFormQuestionDTO questionDto, HttpSession session) {
         this.applicationFormRepository.findById(applicationId).ifPresentOrElse(applicationForm -> {
 
+            ApplicationFormUtils.verifyApplicationFormVersion(questionDto.getVersion(), applicationForm);
+
             ApplicationFormQuestionDTO questionById = applicationForm.getDefinition().getSectionById(sectionId)
                     .getQuestionById(questionId);
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/ApplicationFormTestData.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/ApplicationFormTestData.java
@@ -57,11 +57,11 @@ public class ApplicationFormTestData {
 
     public final static ApplicationFormQuestionDTO SAMPLE_QUESTION = new ApplicationFormQuestionDTO(SAMPLE_QUESTION_ID,
             "ORG_TYPE", null, SAMPLE_QUESTION_FIELD_TITLE, "Answer the question", null, null, null,
-            ResponseTypeEnum.YesNo, Collections.singletonMap("mandatory", true), null);
+            ResponseTypeEnum.YesNo, Collections.singletonMap("mandatory", true), null, 1);
 
     public final static ApplicationFormQuestionDTO SAMPLE_QUESTION_WITH_OPTIONS = new ApplicationFormQuestionDTO(
             SAMPLE_QUESTION_ID, "ORG_TYPE", null, "Select one of the folloiwng", "Answer the question", null, null,
-            null, ResponseTypeEnum.Dropdown, Collections.singletonMap("mandatory", true), SAMPLE_QUESTION_OPTIONS);
+            null, ResponseTypeEnum.Dropdown, Collections.singletonMap("mandatory", true), SAMPLE_QUESTION_OPTIONS, 1);
 
     public final static List<ApplicationFormQuestionDTO> SAMPLE_QUESTION_LIST = new LinkedList<>(
             Collections.singletonList(SAMPLE_QUESTION));


### PR DESCRIPTION
## Description

Covers [GAP-2458](https://technologyprogramme.atlassian.net/browse/GAP-2458), [GAP-2456](https://technologyprogramme.atlassian.net/browse/GAP-2456) and [GAP-2459](https://technologyprogramme.atlassian.net/browse/GAP-2459)

Summary of the changes and the related issue. List any dependencies that are required for this change:
requires version to be passed when patching question and compares to value saved in db before allowing patch to continue
https://github.com/cabinetoffice/gap-find-apply-web/pull/385

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2458]: https://technologyprogramme.atlassian.net/browse/GAP-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAP-2456]: https://technologyprogramme.atlassian.net/browse/GAP-2456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAP-2459]: https://technologyprogramme.atlassian.net/browse/GAP-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ