### PR TITLE
GAP-2501 - stopping super admins appearing in last updated by/date fields

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/listeners/SchemeUpdateListener.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/listeners/SchemeUpdateListener.java
@@ -24,8 +24,15 @@ public class SchemeUpdateListener {
                     if (!authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))) {
                         final AdminSession adminSession = (AdminSession) authentication.getPrincipal();
 
-                        scheme.setLastUpdated(Instant.now());
-                        scheme.setLastUpdatedBy(adminSession.getGrantAdminId());
+                        // if updates were performed by the system or a super admin then don't populate these fields
+                        scheme.getGrantAdmins()
+                                .stream()
+                                .filter(grantAdmin -> grantAdmin.getId().equals(adminSession.getGrantAdminId()))
+                                .findAny()
+                                .ifPresent(grantAdmin -> {
+                                    scheme.setLastUpdated(Instant.now());
+                                    scheme.setLastUpdatedBy(grantAdmin.getId());
+                                });
                     }
                 });
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -346,13 +346,12 @@ public class ApplicationFormService {
 
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     public void updateApplicationOwner(Integer adminId, Integer schemeId) {
-        Optional<ApplicationFormEntity> applicationOptional = this.applicationFormRepository
-                .findByGrantSchemeId(schemeId);
-        if (applicationOptional.isPresent()) {
-            final ApplicationFormEntity application = applicationOptional.get();
-            application.setCreatedBy(adminId);
-            applicationFormRepository.save(application);
-        }
+        this.applicationFormRepository
+                .findByGrantSchemeId(schemeId)
+                .ifPresent(application -> {
+                    application.setCreatedBy(adminId);
+                    applicationFormRepository.save(application);
+                });
     }
 
     public void updateQuestionOrder(final Integer applicationId, final String sectionId, final String questionId,

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -77,7 +77,7 @@ public class GrantAdvertService {
 
     private final FeatureFlagsConfigurationProperties featureFlagsProperties;
 
-    public GrantAdvert  save(GrantAdvert advert) {
+    public GrantAdvert save(GrantAdvert advert) {
         final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         Optional.ofNullable(auth)
                 .ifPresentOrElse(authentication -> {
@@ -85,14 +85,16 @@ public class GrantAdvertService {
                     final GrantAdmin admin = grantAdminRepository.findByGapUserUserSub(adminSession.getUserSub())
                             .orElseThrow(() -> new UserNotFoundException("Could not find an admin with sub " + adminSession.getUserSub()));
 
-                    final Instant updatedAt = Instant.now(clock);
-                    advert.setLastUpdated(updatedAt);
-                    advert.setLastUpdatedBy(admin);
+                    if (advert.getScheme().getGrantAdmins().contains(admin)) {
+                        final Instant updatedAt = Instant.now(clock);
+                        advert.setLastUpdated(updatedAt);
+                        advert.setLastUpdatedBy(admin);
 
-                    advert.getScheme().setLastUpdated(updatedAt);
-                    advert.getScheme().setLastUpdatedBy(adminSession.getGrantAdminId());
+                        advert.getScheme().setLastUpdated(updatedAt);
+                        advert.getScheme().setLastUpdatedBy(adminSession.getGrantAdminId());
 
-                    advert.setValidLastUpdated(true);
+                        advert.setValidLastUpdated(true);
+                    }
                 }, () -> log.warn("Admin session was null. Update must have been performed by a lambda."));
 
         return grantAdvertRepository.save(advert);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -1349,14 +1349,16 @@ class GrantAdvertServiceTest {
         @WithAdminSession
         @Test
         void save_WithAdminSession_Success() {
-            final SchemeEntity scheme = SchemeEntity.builder().build();
-            final GrantAdvert advertToSave = GrantAdvert.builder()
-                    .scheme(scheme)
-                    .build();
             final GrantAdmin grantAdmin = GrantAdmin.builder()
                     .id(1)
                     .build();
             final String now = "2024-02-27T10:15:30Z";
+            final SchemeEntity scheme = SchemeEntity.builder()
+                    .grantAdmins(List.of(grantAdmin))
+                    .build();
+            final GrantAdvert advertToSave = GrantAdvert.builder()
+                    .scheme(scheme)
+                    .build();
 
             final ArgumentCaptor<GrantAdvert> advertCaptor = ArgumentCaptor.forClass(GrantAdvert.class);
 


### PR DESCRIPTION
## Description

There was a requirement to stop super admins appearing in the last updated by fields if they were performing actions such as changing ownership of a grant. 

Ticket # and link
[GAP-2501](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2501)


Summary of the changes and the related issue. List any dependencies that are required for this change:

Added a check to see whether actions being performed on a grant were performed by someone listed as an editor. If they were then we log the dates. If not then we don't. 

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2501]: https://technologyprogramme.atlassian.net/browse/GAP-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ