### PR TITLE
GAP-2455 | handle multiple editors section deleted

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -233,7 +233,7 @@ public class ApplicationFormService {
         String questionId = UUID.randomUUID().toString();
 
         this.applicationFormRepository.findById(applicationId).ifPresentOrElse(applicationForm -> {
-            ApplicationFormSectionDTO sectionDTO = null;
+            ApplicationFormSectionDTO sectionDTO;
             try {
                 sectionDTO = applicationForm.getDefinition().getSectionById(sectionId);
             } catch (NotFoundException e) {

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -237,7 +237,7 @@ public class ApplicationFormService {
             try {
                 sectionDTO = applicationForm.getDefinition().getSectionById(sectionId);
             } catch (NotFoundException e) {
-                //If the section does not exist here it must have been deleted.
+                //If the section does not exist here it must have been recently deleted by another editor.
                 throw new ConflictException("MULTIPLE_EDITORS_SECTION_DELETED");
             }
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormServiceTest.java
@@ -497,6 +497,19 @@ class ApplicationFormServiceTest {
                     .isInstanceOf(ConstraintViolationException.class)
                     .hasMessage("options[2].<list element>: Enter an option");
         }
+
+        @Test
+        void addNewQuestionOptionValueConflictExceptionTest() {
+            final HttpSession session = new MockHttpSession();
+            when(ApplicationFormServiceTest.this.applicationFormRepository.findById(SAMPLE_APPLICATION_ID))
+                    .thenReturn(Optional.of(SAMPLE_EMPTY_APPLICATION_FORM_ENTITY));
+
+            assertThatThrownBy(() -> applicationFormService
+                    .addQuestionToApplicationForm(SAMPLE_APPLICATION_ID, SAMPLE_SECTION_ID,
+                            SAMPLE_QUESTION_OPTIONS_CONTENT_INVALID_POST_DTO, session))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessage("MULTIPLE_EDITORS_SECTION_DELETED");
+        }
     }
 
     @Nested

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/ApplicationFormTestData.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/testdata/ApplicationFormTestData.java
@@ -111,6 +111,8 @@ public class ApplicationFormTestData {
     public final static ApplicationDefinitionDTO SAMPLE_APPLICATION_DEFINITION = new ApplicationDefinitionDTO(
             SAMPLE_SECTIONS_LIST);
 
+    public final static ApplicationDefinitionDTO SAMPLE_EMPTY_APPLICATION_DEFINITION = new ApplicationDefinitionDTO(Collections.emptyList());
+
     public final static ApplicationDefinitionDTO SAMPLE_APPLICATION_DEFINITION_DELETE_SECTION = new ApplicationDefinitionDTO(
             SAMPLE_SECTIONS_LIST_DELETE_SECTION);
 
@@ -152,6 +154,12 @@ public class ApplicationFormTestData {
             SAMPLE_APPLICATION_ID, SAMPLE_SCHEME_ID, SAMPLE_VERSION, SAMPLE_CREATED, SAMPLE_CREATED_BY,
             SAMPLE_LAST_UPDATED, SAMPLE_LAST_UPDATE_BY, SAMPLE_LAST_PUBLISHED, SAMPLE_APPLICATION_NAME,
             ApplicationStatusEnum.DRAFT, SAMPLE_APPLICATION_DEFINITION);
+
+    public final static ApplicationFormEntity SAMPLE_EMPTY_APPLICATION_FORM_ENTITY = new ApplicationFormEntity(
+            SAMPLE_APPLICATION_ID, SAMPLE_SCHEME_ID, SAMPLE_VERSION, SAMPLE_CREATED, SAMPLE_CREATED_BY,
+            SAMPLE_LAST_UPDATED, SAMPLE_LAST_UPDATE_BY, SAMPLE_LAST_PUBLISHED, SAMPLE_APPLICATION_NAME,
+            ApplicationStatusEnum.DRAFT, SAMPLE_EMPTY_APPLICATION_DEFINITION);
+
 
     public final static ApplicationFormEntity SAMPLE_APPLICATION_FORM_ENTITY_DELETE_SECTION = new ApplicationFormEntity(
             SAMPLE_APPLICATION_ID, SAMPLE_SCHEME_ID, SAMPLE_VERSION, SAMPLE_CREATED, SAMPLE_CREATED_BY,


### PR DESCRIPTION
## Description

Ticket # and link

[GAP-2455](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2455)

[Related pr (frontend)](https://github.com/cabinetoffice/gap-find-apply-web/pull/393)

Adds logic to the add question service: now throws a conflict exception when the queried section doesn't exist. (It must have been deleted by another editor)

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2455]: https://technologyprogramme.atlassian.net/browse/GAP-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ