### PR TITLE
TMI2-721: changes preview date format for midnight times

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertService.java
@@ -215,9 +215,9 @@ public class PagesAdvertService {
         return AdvertPreviewPageDto.builder().grantName(grantAdvert.getGrantAdvertName())
                 .grantShortDescription(response.nullCheckSingleResponse("grantDetails", "1", "grantShortDescription"))
                 .grantApplicationOpenDate(buildDateForPreview(
-                        response.nullCheckMultiResponse(ADVERT_DATES_SECTION_ID, "1", OPENING_DATE_ID)))
+                        response.nullCheckMultiResponse(ADVERT_DATES_SECTION_ID, "1", OPENING_DATE_ID), OPENING_DATE_ID))
                 .grantApplicationCloseDate(buildDateForPreview(
-                        response.nullCheckMultiResponse(ADVERT_DATES_SECTION_ID, "1", CLOSING_DATE_ID)))
+                        response.nullCheckMultiResponse(ADVERT_DATES_SECTION_ID, "1", CLOSING_DATE_ID), CLOSING_DATE_ID))
                 .tabs(advertPreviewTabs).build();
 
     }
@@ -230,7 +230,7 @@ public class PagesAdvertService {
         return multiResponse[1];
     }
 
-    private String buildDateForPreview(String[] date) {
+    private String buildDateForPreview(String[] date, String dateId) {
         if (date == null) {
             return "";
         }
@@ -238,9 +238,22 @@ public class PagesAdvertService {
         int[] dateInts = Arrays.stream(date).mapToInt(Integer::parseInt).toArray();
         LocalDateTime castDate = LocalDateTime.of(dateInts[2], dateInts[1], dateInts[0], dateInts[3], dateInts[4]);
 
+        if (castDate.toLocalTime().equals(LocalDateTime.MIN.toLocalTime())) {
+            final String previewMidnightDatePattern = "d MMMM u, ";
+            final DateTimeFormatter previewMidnightFormatter = DateTimeFormatter.ofPattern(previewMidnightDatePattern).withLocale(Locale.UK);
+            if(dateId.equals(CLOSING_DATE_ID)) {
+                castDate = castDate.minusMinutes(1);
+            }
+            if(dateId.equals(OPENING_DATE_ID)) {
+                castDate = castDate.plusMinutes(1);
+            }
+            return previewMidnightFormatter.format(castDate) + "(Midnight) "
+                    + DateTimeFormatter.ofPattern("hh:mma", Locale.UK).format(castDate);
+        }
+
         // "30 November 2022, 12:01am"
-        String previewDatePattern = "d MMMM u, hh:mma";
-        DateTimeFormatter previewFormatter = DateTimeFormatter.ofPattern(previewDatePattern).withLocale(Locale.UK);
+        final String previewDatePattern = "d MMMM u, hh:mma";
+        final DateTimeFormatter previewFormatter = DateTimeFormatter.ofPattern(previewDatePattern).withLocale(Locale.UK);
         return previewFormatter.format(castDate);
 
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertService.java
@@ -243,8 +243,7 @@ public class PagesAdvertService {
             final DateTimeFormatter previewMidnightFormatter = DateTimeFormatter.ofPattern(previewMidnightDatePattern).withLocale(Locale.UK);
             if(dateId.equals(CLOSING_DATE_ID)) {
                 castDate = castDate.minusMinutes(1);
-            }
-            if(dateId.equals(OPENING_DATE_ID)) {
+            } else if(dateId.equals(OPENING_DATE_ID)) {
                 castDate = castDate.plusMinutes(1);
             }
             return previewMidnightFormatter.format(castDate) + "(Midnight) "

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/pages/PagesAdvertServiceTest.java
@@ -176,11 +176,11 @@ class PagesAdvertServiceTest {
 
         final GrantAdvertQuestionResponse openingDateResponse = GrantAdvertQuestionResponse.builder()
                 .id("grantApplicationOpenDate").seen(true)
-                .multiResponse(new String[] { "10", "12", "2022", "00", "01" }).build();
+                .multiResponse(new String[] { "10", "12", "2022", "00", "00" }).build();
 
         final GrantAdvertQuestionResponse closingDateResponse = GrantAdvertQuestionResponse.builder()
                 .id("grantApplicationCloseDate").seen(true)
-                .multiResponse(new String[] { "10", "12", "2023", "23", "59" }).build();
+                .multiResponse(new String[] { "11", "12", "2023", "00", "00" }).build();
 
         final GrantAdvertPageResponse datesPage = GrantAdvertPageResponse.builder().id("1")
                 .status(GrantAdvertPageResponseStatus.COMPLETED)
@@ -248,8 +248,8 @@ class PagesAdvertServiceTest {
 
             assertThat(advertPreviewPageDto.getGrantName()).isEqualTo(grantAdvertName);
             assertThat(advertPreviewPageDto.getGrantShortDescription()).isEqualTo(grantShortDescription);
-            assertThat(advertPreviewPageDto.getGrantApplicationOpenDate()).isEqualTo("10 December 2022, 12:01am");
-            assertThat(advertPreviewPageDto.getGrantApplicationCloseDate()).isEqualTo("10 December 2023, 11:59pm");
+            assertThat(advertPreviewPageDto.getGrantApplicationOpenDate()).isEqualTo("10 December 2022, (Midnight) 12:01am");
+            assertThat(advertPreviewPageDto.getGrantApplicationCloseDate()).isEqualTo("10 December 2023, (Midnight) 11:59pm");
             assertThat(advertPreviewPageDto.getTabs().get(0).getContent())
                     .isEqualTo(String.format(richTextTemplate, "summary"));
             assertThat(advertPreviewPageDto.getTabs().get(1).getContent())


### PR DESCRIPTION
## Description
Changes advert preview date format for midnight dates to be 1 minute past midnight for opening dates and 1 minute before midnight for closing dates. The text "Midnight" has also been added before the date

Ticket # and link
TMI2-721: https://technologyprogramme.atlassian.net/browse/TMI2-721

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):
<img width="1090" alt="Screenshot 2024-03-13 at 10 51 18" src="https://github.com/cabinetoffice/gap-find-admin-backend/assets/99667350/9aebd326-bb45-40ea-9d81-687f55907b10">


# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
