### PR TITLE
GAP-2446: Multiple editors publishing adverts

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -17,6 +17,7 @@ import gov.cabinetoffice.gap.adminbackend.enums.AdvertDefinitionQuestionResponse
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertPageResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertSectionResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.GrantAdvertException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.UserNotFoundException;
@@ -180,8 +181,11 @@ public class GrantAdvertService {
         GrantAdvert grantAdvert = grantAdvertRepository.findById(pagePatchDto.getGrantAdvertId())
                 .orElseThrow(() -> new NotFoundException(
                         String.format("GrantAdvert with id %s not found", pagePatchDto.getGrantAdvertId())));
+
+        advertPublishedOrScheduledError(grantAdvert);
         // adds the static opening and closing time to the date question
         addStaticTimeToDateQuestion(pagePatchDto);
+
 
         // if response/section/page does not exist, create it. If it does exist, update it
         GrantAdvertResponse response = Optional.ofNullable(grantAdvert.getResponse()).orElseGet(() -> {
@@ -604,5 +608,11 @@ public class GrantAdvertService {
 
                     grantAdvertRepository.save(advert);
                 });
+    }
+
+    public static void advertPublishedOrScheduledError(GrantAdvert grantAdvert) {
+        if (grantAdvert.getStatus() == GrantAdvertStatus.PUBLISHED || grantAdvert.getStatus() == GrantAdvertStatus.SCHEDULED) {
+            throw new ConflictException("GRANT_ADVERT_MULTIPLE_EDITORS");
+        }
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -18,6 +18,7 @@ import gov.cabinetoffice.gap.adminbackend.enums.AdvertDefinitionQuestionResponse
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertPageResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertSectionResponseStatus;
 import gov.cabinetoffice.gap.adminbackend.enums.GrantAdvertStatus;
+import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
 import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
 import gov.cabinetoffice.gap.adminbackend.mappers.GrantAdvertMapper;
 import gov.cabinetoffice.gap.adminbackend.mappers.GrantAdvertMapperImpl;
@@ -607,14 +608,14 @@ class GrantAdvertServiceTest {
 
             final GrantAdvert advert = GrantAdvert.builder().build();
 
-            String[] openingMultiResponse = new String[] { "10", "10", "2010", "13:00" };
+            String[] openingMultiResponse = new String[]{"10", "10", "2010", "13:00"};
             GrantAdvertQuestionResponse openingDateQuestion = GrantAdvertQuestionResponse.builder().id(OPENING_DATE_ID)
                     .multiResponse(openingMultiResponse).build();
-            String[] closingMultiResponse = new String[] { "12", "12", "2012", "13:00" };
+            String[] closingMultiResponse = new String[]{"12", "12", "2012", "13:00"};
             GrantAdvertQuestionResponse closingDateQuestion = GrantAdvertQuestionResponse.builder().id(CLOSING_DATE_ID)
                     .multiResponse(closingMultiResponse).build();
-            String[] expectedOpeningMultiResponse = new String[] { "10", "10", "2010", "13", "00" };
-            String[] expectedClosingMultiResponse = new String[] { "12", "12", "2012", "13", "00" };
+            String[] expectedOpeningMultiResponse = new String[]{"10", "10", "2010", "13", "00"};
+            String[] expectedClosingMultiResponse = new String[]{"12", "12", "2012", "13", "00"};
 
             GrantAdvertPageResponse datePage = GrantAdvertPageResponse.builder().id(pageId)
                     .status(GrantAdvertPageResponseStatus.COMPLETED)
@@ -659,6 +660,16 @@ class GrantAdvertServiceTest {
             assertThat(closingQuestion.get().getMultiResponse()).isEqualTo(expectedClosingMultiResponse);
         }
 
+        @Test
+        void updatePageResponseThrowsConflictException() {
+            final GrantAdvert advert = GrantAdvert.builder().status(GrantAdvertStatus.PUBLISHED).build();
+            when(grantAdvertRepository.findById(grantAdvertId)).thenReturn(Optional.of(advert));
+            GrantAdvertPageResponseValidationDto datePagePatchDto = GrantAdvertPageResponseValidationDto.builder()
+                    .grantAdvertId(grantAdvertId).sectionId(ADVERT_DATES_SECTION_ID).page(samplePageDto).build();
+
+            assertThrows(ConflictException.class, () -> grantAdvertService.updatePageResponse(datePagePatchDto));
+
+        }
     }
 
     // TODO refactor this test and the underlying service methods to be more maintainable


### PR DESCRIPTION
## Description

Ticket # and link [GAP-2446](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2446)

Adds a static method to the AdvertService to check if an advert is published or scheduled, if so throws a conflict exception.

Summary of the changes and the related issue. List any dependencies that are required for this change:
Requires [FE PR ](https://github.com/cabinetoffice/gap-find-apply-web/pull/395) to be caught properly.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
