### PR TITLE
GAP-2487: Replace contentful webhooks with synchronous api call

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/config/JacksonConfig.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/config/JacksonConfig.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.adminbackend.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
@@ -22,6 +23,7 @@ public class JacksonConfig {
         objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/config/OpenSearchConfig.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/config/OpenSearchConfig.java
@@ -1,0 +1,21 @@
+package gov.cabinetoffice.gap.adminbackend.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Configuration
+@ConfigurationProperties(prefix = "open-search")
+public class OpenSearchConfig {
+        private String url;
+        private String domain;
+        private String username;
+        private String password;
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -425,7 +425,6 @@ public class GrantAdvertService {
                     contentfulProperties.getSpaceId(), contentfulProperties.getEnvironmentId(),
                     contentfulAdvert.getId());
             log.debug(url);
-
             webClientBuilder.build()
                     .patch()
                     .uri(url)
@@ -436,7 +435,8 @@ public class GrantAdvertService {
                     })
                     .bodyValue(requestBody)
                     .retrieve()
-                    .bodyToMono(Object.class)
+                    .bodyToMono(Void.class)
+                    .doOnError(exception -> log.error("createRichTextQuestionsInContentful failed on PATCH to {}, with message: {}", url, exception.getMessage()))
                     .block();
         }
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -50,31 +50,19 @@ import static gov.cabinetoffice.gap.adminbackend.validation.validators.AdvertPag
 public class GrantAdvertService {
 
     private static final String CONTENTFUL_LOCALE = "en-US";
-
     private static final String CONTENTFUL_GRANT_TYPE_ID = "grantDetails";
-
     private final AdvertDefinition advertDefinition;
-
     private final GrantAdvertRepository grantAdvertRepository;
-
     private final GrantAdminRepository grantAdminRepository;
-
     private final SchemeRepository schemeRepository;
-
     private final GrantAdvertMapper grantAdvertMapper;
-
     private final CMAClient contentfulManagementClient;
-
     private final CDAClient contentfulDeliveryClient;
-
     private final UserService userService;
-
+    private final OpenSearchService openSearchService;
     private final WebClient.Builder webClientBuilder;
-
     private final Clock clock;
-
     private final ContentfulConfigProperties contentfulProperties;
-
     private final FeatureFlagsConfigurationProperties featureFlagsProperties;
 
     public GrantAdvert  save(GrantAdvert advert) {
@@ -288,7 +276,7 @@ public class GrantAdvertService {
     public GrantAdvert publishAdvert(UUID advertId) {
         final GrantAdvert advert = getAdvertById(advertId);
 
-        final CMAEntry contentfulAdvert;
+        CMAEntry contentfulAdvert;
 
         // if advert has not been published previously
         if (advert.getFirstPublishedDate() == null) {
@@ -300,7 +288,8 @@ public class GrantAdvertService {
             advert.setLastPublishedDate(Instant.now());
         }
 
-        contentfulManagementClient.entries().publish(contentfulAdvert);
+        contentfulAdvert = contentfulManagementClient.entries().publish(contentfulAdvert);
+        openSearchService.indexEntry(contentfulAdvert);
 
         advert.setStatus(GrantAdvertStatus.PUBLISHED);
         advert.setContentfulSlug(contentfulAdvert.getField("label", CONTENTFUL_LOCALE));
@@ -313,9 +302,11 @@ public class GrantAdvertService {
     public void unpublishAdvert(UUID advertId) {
         final GrantAdvert advert = this.getAdvertById(advertId);
 
-        final CMAEntry contentfulAdvert = contentfulManagementClient.entries().fetchOne(advert.getContentfulEntryId());
+        CMAEntry contentfulAdvert = contentfulManagementClient.entries().fetchOne(advert.getContentfulEntryId());
 
-        contentfulManagementClient.entries().unPublish(contentfulAdvert);
+        contentfulAdvert = contentfulManagementClient.entries().unPublish(contentfulAdvert);
+        openSearchService.removeIndexEntry(contentfulAdvert);
+
         advert.setStatus(GrantAdvertStatus.DRAFT);
         advert.setUnpublishedDate(Instant.now());
 
@@ -426,7 +417,7 @@ public class GrantAdvertService {
                         .anyMatch(qr -> qr.getId().equals(q.getId())))
                 .toList();
 
-        if (responses != null && !responses.isEmpty()) {
+        if (!responses.isEmpty()) {
             final String requestBody = buildRichTextPatchRequestBody(responses);
 
             // send to contentful
@@ -445,8 +436,7 @@ public class GrantAdvertService {
                     })
                     .bodyValue(requestBody)
                     .retrieve()
-                    .bodyToMono(Void.class)
-                    .doOnError(exception -> log.error("createRichTextQuestionsInContentful failed on PATCH to {}, with message: {}", url, exception.getMessage()))
+                    .bodyToMono(Object.class)
                     .block();
         }
     }

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchService.java
@@ -1,0 +1,68 @@
+package gov.cabinetoffice.gap.adminbackend.services;
+
+import com.contentful.java.cma.model.CMAEntry;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cabinetoffice.gap.adminbackend.config.OpenSearchConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenSearchService {
+
+    private final WebClient.Builder webClientBuilder;
+    private final OpenSearchConfig openSearchConfig;
+
+    public void indexEntry(final CMAEntry contentfulEntry) {
+        final String body = contentfulEntryToJsonString(contentfulEntry);
+        webClientBuilder.build().put()
+                .uri(createUrl(contentfulEntry))
+                .body(BodyInserters.fromValue(body))
+                .header(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE + "; " + StandardCharsets.UTF_8.name())
+                .header(AUTHORIZATION, createAuthHeader())
+                .retrieve()
+                .bodyToMono(void.class)
+                .block();
+    }
+
+    public void removeIndexEntry(final CMAEntry contentfulEntry) {
+        final String body = contentfulEntryToJsonString(contentfulEntry.getSystem());
+        webClientBuilder.build().method(HttpMethod.DELETE)
+                .uri(createUrl(contentfulEntry))
+                .body(BodyInserters.fromValue(body))
+                .header(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE + "; " + StandardCharsets.UTF_8.name())
+                .header(AUTHORIZATION, createAuthHeader())
+                .retrieve()
+                .bodyToMono(void.class)
+                .block();
+    }
+
+    private String createUrl(final CMAEntry contentfulEntry) {
+        return openSearchConfig.getUrl() + "/" + openSearchConfig.getDomain() + "/_doc/" + contentfulEntry.getId();
+    }
+
+    private String createAuthHeader() {
+        final String auth = openSearchConfig.getUsername() + ":" + openSearchConfig.getPassword();
+        return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes());
+    }
+
+    private String contentfulEntryToJsonString(final Object contentfulEntry) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        final String contentfulObject = objectMapper.valueToTree(contentfulEntry).toString();
+        return contentfulObject.replace("\"system\":", "\"sys\":");
+    }
+}

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchService.java
@@ -35,6 +35,7 @@ public class OpenSearchService {
                 .header(AUTHORIZATION, createAuthHeader())
                 .retrieve()
                 .bodyToMono(void.class)
+                .doOnError(e -> log.error("Failed to create an index entry for ad " + contentfulEntry.getId() + "in open search: {}", e.getMessage()))
                 .block();
     }
 
@@ -47,6 +48,7 @@ public class OpenSearchService {
                 .header(AUTHORIZATION, createAuthHeader())
                 .retrieve()
                 .bodyToMono(void.class)
+                .doOnError(e -> log.error("Failed to delete an index entry for ad " + contentfulEntry.getId() + "in open search: {}", e.getMessage()))
                 .block();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,3 +76,8 @@ aws.kms.origin=origin
 aws.kms.stage=stage
 
 spring.jpa.properties.hibernate.order_by.default_null_ordering=last
+
+open-search.url=https://search-url
+open-search.domain=domain
+open-search.username=username
+open-search.password=password

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchServiceTest.java
@@ -1,0 +1,94 @@
+package gov.cabinetoffice.gap.adminbackend.services;
+
+import com.contentful.java.cma.model.CMAEntry;
+import com.contentful.java.cma.model.CMASystem;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cabinetoffice.gap.adminbackend.config.OpenSearchConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.*;
+
+@SpringJUnitConfig
+class OpenSearchServiceTest {
+    @Spy
+    @InjectMocks
+    private OpenSearchService openSearchService;
+
+    @Mock
+    private OpenSearchConfig openSearchConfig;
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private CMAEntry contentfulEntry;
+
+    @BeforeEach
+    void beforeEach() {
+        when(openSearchConfig.getUrl()).thenReturn("testUrl");
+        when(openSearchConfig.getDomain()).thenReturn("testDomain");
+        when(openSearchConfig.getUsername()).thenReturn("testUsername");
+        when(openSearchConfig.getPassword()).thenReturn("testPassword");
+
+        contentfulEntry = new CMAEntry();
+        final CMASystem system = new CMASystem();
+        system.setId("testId");
+        contentfulEntry.setSystem(system);
+    }
+
+    @Test
+    void indexEntry() {
+        final WebClient mockWebClient = mock(WebClient.class);
+        final WebClient.RequestBodyUriSpec mockRequestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
+        final WebClient.RequestHeadersSpec mockRequestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        final WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
+        final JsonNode mockJsonNode = mock(JsonNode.class);
+
+        when(objectMapper.valueToTree(any())).thenReturn(mockJsonNode);
+        when(mockJsonNode.toString()).thenReturn("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}");
+        when(webClientBuilder.build()).thenReturn(mockWebClient);
+        when(mockWebClient.put()).thenReturn(mockRequestBodyUriSpec);
+        when(mockRequestBodyUriSpec.uri("testUrl/testDomain/_doc/testId")).thenReturn(mockRequestBodyUriSpec);
+        when(mockRequestBodyUriSpec.body(any(), eq(String.class))).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.header("Content-Type", "application/json; UTF-8")).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.header("Authorization", "Basic dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==")).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.retrieve()).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.bodyToMono(void.class)).thenReturn(Mono.empty());
+
+        openSearchService.indexEntry(contentfulEntry);
+    }
+
+    @Test
+    void removeIndexEntry() {
+        final WebClient mockWebClient = mock(WebClient.class);
+        final WebClient.RequestBodyUriSpec mockRequestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
+        final WebClient.RequestHeadersSpec mockRequestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        final WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
+        final JsonNode mockJsonNode = mock(JsonNode.class);
+
+        when(objectMapper.valueToTree(any())).thenReturn(mockJsonNode);
+        when(mockJsonNode.toString()).thenReturn("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}");
+        when(webClientBuilder.build()).thenReturn(mockWebClient);
+        when(mockWebClient.method(HttpMethod.DELETE)).thenReturn(mockRequestBodyUriSpec);
+        when(mockRequestBodyUriSpec.uri("testUrl/testDomain/_doc/testId")).thenReturn(mockRequestBodyUriSpec);
+        when(mockRequestBodyUriSpec.body(any(), eq(String.class))).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.header("Content-Type", "application/json; UTF-8")).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.header("Authorization", "Basic dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==")).thenReturn(mockRequestHeadersSpec);
+        when(mockRequestHeadersSpec.retrieve()).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.bodyToMono(void.class)).thenReturn(Mono.empty());
+
+        openSearchService.removeIndexEntry(contentfulEntry);
+    }
+}


### PR DESCRIPTION
## Description

Ticket [GAP-2487](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2487)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Replacing contentfuls webhooks that update elastic search with manual api calls from our backend
- Prevents race conditions in the webhooks
- Prevents async nature of webhooks sometimes taking 15 mins to trigger

TODO:
- Refactor cypress to seed elastic when seeding contentful
- Infra PR to add secrets to admin backend task def

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:


https://github.com/cabinetoffice/gap-find-admin-backend/assets/101722961/61c3467e-94c9-4ea1-9354-8984191ccee5



# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.


[GAP-2487]: https://technologyprogramme.atlassian.net/browse/GAP-2487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ