### PR TITLE
GAP-2510: Fixing errors caused by setting last updated fields on grant adverts

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -70,19 +70,21 @@ public class GrantAdvertService {
         final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         Optional.ofNullable(auth)
                 .ifPresentOrElse(authentication -> {
-                    final AdminSession adminSession = (AdminSession) authentication.getPrincipal();
-                    final GrantAdmin admin = grantAdminRepository.findByGapUserUserSub(adminSession.getUserSub())
-                            .orElseThrow(() -> new UserNotFoundException("Could not find an admin with sub " + adminSession.getUserSub()));
+                    if (!HelperUtils.isAnonymousSession()) {
+                        final AdminSession adminSession = (AdminSession) authentication.getPrincipal();
+                        final GrantAdmin admin = grantAdminRepository.findByGapUserUserSub(adminSession.getUserSub())
+                                .orElseThrow(() -> new UserNotFoundException("Could not find an admin with sub " + adminSession.getUserSub()));
 
-                    if (advert.getScheme().getGrantAdmins().contains(admin)) {
-                        final Instant updatedAt = Instant.now(clock);
-                        advert.setLastUpdated(updatedAt);
-                        advert.setLastUpdatedBy(admin);
+                        if (advert.getScheme().getGrantAdmins().contains(admin)) {
+                            final Instant updatedAt = Instant.now(clock);
+                            advert.setLastUpdated(updatedAt);
+                            advert.setLastUpdatedBy(admin);
 
-                        advert.getScheme().setLastUpdated(updatedAt);
-                        advert.getScheme().setLastUpdatedBy(adminSession.getGrantAdminId());
+                            advert.getScheme().setLastUpdated(updatedAt);
+                            advert.getScheme().setLastUpdatedBy(adminSession.getGrantAdminId());
 
-                        advert.setValidLastUpdated(true);
+                            advert.setValidLastUpdated(true);
+                        }
                     }
                 }, () -> log.warn("Admin session was null. Update must have been performed by a lambda."));
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/HelperUtils.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/HelperUtils.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import gov.cabinetoffice.gap.adminbackend.exceptions.UnauthorizedException;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -13,9 +14,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 
 public class HelperUtils {
+
+    public static final String ROLE_ANONYMOUS = "ROLE_ANONYMOUS";
 
     /**
      * Used to generate a safely encoded URL, incl. any query params This method will
@@ -88,4 +93,21 @@ public class HelperUtils {
         return userServiceToken.getValue();
     }
 
+
+    /**
+     * Verifies whether a session is anonymous in spring security or not.
+     *
+     * Useful method to have because some of our lambdas use encrypted headers to bypass spring security.
+     * @return
+     */
+    public static boolean isAnonymousSession() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(authentication -> authentication.getAuthorities()
+                        .stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .toList())
+                .orElse(Collections.emptyList())
+                .stream()
+                .anyMatch(auth -> auth.equals(ROLE_ANONYMOUS));
+    }
 }

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/HelperUtilsTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/utils/HelperUtilsTest.java
@@ -1,14 +1,37 @@
 package gov.cabinetoffice.gap.adminbackend.utils;
 
+import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import static gov.cabinetoffice.gap.adminbackend.testdata.SchemeTestData.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 class HelperUtilsTest {
+
+    @Mock
+    private Authentication auth;
+
+    @Mock
+    private SecurityContext context;
 
     @Test
     void buildUrlWithNoParamsTest() {
@@ -41,6 +64,48 @@ class HelperUtilsTest {
         assertThat(schemeJson).isEqualTo("{\"schemeId\":" + SAMPLE_SCHEME_ID + ",\"funderId\":" + SAMPLE_ORGANISATION_ID
                 + ",\"name\":\"" + SAMPLE_SCHEME_NAME + "\",\"ggisReference\":\"" + SAMPLE_GGIS_REFERENCE
                 + "\",\"contactEmail\":\"" + SAMPLE_SCHEME_CONTACT + "\",\"lastUpdatedByADeletedUser\":false}");
+    }
+
+    @Test
+    void isAnonymousSession_ReturnsTrueIfAnonymousSession() {
+
+        Authentication auth = Mockito.mock(Authentication.class);
+        SecurityContext context = mock(SecurityContext.class);
+
+        try (MockedStatic<SecurityContextHolder> securityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
+            securityContextHolder.when(SecurityContextHolder::getContext).thenReturn(context);
+
+            final GrantedAuthority role = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+
+            when(context.getAuthentication())
+                    .thenReturn(auth);
+
+            when(auth.getAuthorities())
+                    .thenReturn((Collection) List.of(role));
+
+            assertThat(HelperUtils.isAnonymousSession()).isTrue();
+        }
+    }
+
+    @Test
+    void isAnonymousSession_ReturnsFalseIfIdNotAnonymousSession() {
+
+        Authentication auth = Mockito.mock(Authentication.class);
+        SecurityContext context = mock(SecurityContext.class);
+
+        try (MockedStatic<SecurityContextHolder> securityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
+            securityContextHolder.when(SecurityContextHolder::getContext).thenReturn(context);
+
+            final GrantedAuthority role = new SimpleGrantedAuthority("ROLE_ADMIN");
+
+            when(context.getAuthentication())
+                    .thenReturn(auth);
+
+            when(auth.getAuthorities())
+                    .thenReturn((Collection) List.of(role));
+
+            assertThat(HelperUtils.isAnonymousSession()).isFalse();
+        }
     }
 
 }


### PR DESCRIPTION
## Description
Fixing errors caused by setting the last updated dates on grant adverts when authenticated as an anonymous user. This occurs when one of our lambdas performs updates on a grant advert. 

Ticket # and link
[GAP-2510](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2510)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Added a helper method to check whether an authenticated session is anonymous or not and then called this before saving a grant advert. 

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
