### PR TITLE
Bugfix: Refactor submission export to use existing UserServiceClient to retrieve user email by sub

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsController.java
@@ -1,7 +1,6 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
 import gov.cabinetoffice.gap.adminbackend.annotations.LambdasHeaderValidator;
-import gov.cabinetoffice.gap.adminbackend.config.LambdaSecretConfigProperties;
 import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
 import gov.cabinetoffice.gap.adminbackend.dtos.UrlDTO;
@@ -45,8 +44,6 @@ public class SubmissionsController {
     private final S3Service s3Service;
 
     private final FileService fileService;
-
-    private final LambdaSecretConfigProperties lambdaSecretConfigProperties;
 
     @GetMapping(value = "/spotlight-export/{applicationId}", produces = EXPORT_CONTENT_TYPE)
     @CheckSchemeOwnership
@@ -107,7 +104,7 @@ public class SubmissionsController {
             final @PathVariable @NotNull UUID batchExportId) {
         try {
             final LambdaSubmissionDefinition submission = submissionsService.getSubmissionInfo(submissionId,
-                    batchExportId, lambdaSecretConfigProperties.getSecret());
+                    batchExportId);
             return ResponseEntity.ok(submission);
         }
         catch (NotFoundException e) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/SubmissionsControllerTest.java
@@ -1,6 +1,5 @@
 package gov.cabinetoffice.gap.adminbackend.controllers;
 
-import gov.cabinetoffice.gap.adminbackend.config.LambdaSecretConfigProperties;
 import gov.cabinetoffice.gap.adminbackend.config.LambdasInterceptor;
 import gov.cabinetoffice.gap.adminbackend.constants.SpotlightExports;
 import gov.cabinetoffice.gap.adminbackend.dtos.S3ObjectKeyDTO;
@@ -60,9 +59,6 @@ class SubmissionsControllerTest {
 
     @MockBean
     private SubmissionsService submissionsService;
-
-    @MockBean
-    private LambdaSecretConfigProperties mockLambdaSecretConfigProperties;
 
     @MockBean
     private S3Service s3Service;
@@ -206,8 +202,7 @@ class SubmissionsControllerTest {
         @Test
         void happyPath() throws Exception {
             final LambdaSubmissionDefinition lambdaSubmissionDefinition = LambdaSubmissionDefinition.builder().build();
-            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
-            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
+            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class)))
                     .thenReturn(lambdaSubmissionDefinition);
 
             mockMvc.perform(
@@ -219,8 +214,7 @@ class SubmissionsControllerTest {
 
         @Test
         void unauthorisedPath() throws Exception {
-            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
-            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
+            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class)))
                     .thenThrow(new UnauthorizedException());
 
             mockMvc.perform(
@@ -231,8 +225,7 @@ class SubmissionsControllerTest {
 
         @Test
         void resourceNotFoundPath() throws Exception {
-            when(mockLambdaSecretConfigProperties.getSecret()).thenReturn("secret");
-            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class), anyString()))
+            when(submissionsService.getSubmissionInfo(any(UUID.class), any(UUID.class)))
                     .thenThrow(new NotFoundException());
 
             mockMvc.perform(


### PR DESCRIPTION
## Description

Remove the existing private method which retrieves the user's email from the user service from the submission service & use the existing method in the UserServiceClient which is already setup to use the encrypted secret.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
