### PR TITLE
TMI2-725 - Remove Contentful slug when unpublishing an advert

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -319,6 +319,7 @@ public class GrantAdvertService {
 
         contentfulManagementClient.entries().unPublish(contentfulAdvert);
         advert.setStatus(GrantAdvertStatus.DRAFT);
+        advert.setContentfulSlug(null);
         advert.setUnpublishedDate(Instant.now());
 
         save(advert);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -1044,6 +1044,7 @@ class GrantAdvertServiceTest {
             assertThat(advertCaptor.getValue().getId()).isEqualTo(grantAdvertId);
             assertThat(advertCaptor.getValue().getStatus()).isEqualTo(GrantAdvertStatus.DRAFT);
             assertThat(advertCaptor.getValue().getUnpublishedDate()).isNotNull();
+            assertThat(advertCaptor.getValue().getContentfulSlug()).isNull();
         }
 
         @Test
@@ -1071,6 +1072,7 @@ class GrantAdvertServiceTest {
             assertThat(advertCaptor.getValue().getId()).isEqualTo(grantAdvertId);
             assertThat(advertCaptor.getValue().getStatus()).isEqualTo(GrantAdvertStatus.DRAFT);
             assertThat(advertCaptor.getValue().getUnpublishedDate()).isNotNull();
+            assertThat(advertCaptor.getValue().getContentfulSlug()).isNull();
         }
 
     }


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-725

Publishing an advert with the same name as a previously published advert causes an error because each advert requires a unique Contentful slug.

Updating the unpublish method so that Contentful slugs are removed and can be used again.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
