### PR TITLE
Multiple editors - handle editing recently deleted section

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/utils/ApplicationFormUtils.java
@@ -1,7 +1,9 @@
 package gov.cabinetoffice.gap.adminbackend.utils;
 
+import gov.cabinetoffice.gap.adminbackend.dtos.application.ApplicationFormSectionDTO;
 import gov.cabinetoffice.gap.adminbackend.entities.ApplicationFormEntity;
 import gov.cabinetoffice.gap.adminbackend.exceptions.ConflictException;
+import gov.cabinetoffice.gap.adminbackend.exceptions.NotFoundException;
 import gov.cabinetoffice.gap.adminbackend.models.AdminSession;
 
 import java.time.Instant;
@@ -23,4 +25,14 @@ public class ApplicationFormUtils {
         }
     }
 
+    public static ApplicationFormSectionDTO verifyAndGetApplicationFormSection(ApplicationFormEntity applicationForm, String sectionId) {
+        ApplicationFormSectionDTO sectionDTO;
+        try {
+            sectionDTO = applicationForm.getDefinition().getSectionById(sectionId);
+        } catch (NotFoundException e) {
+            // If the section is not found it must have recently been deleted by another editor.
+            throw new ConflictException("MULTIPLE_EDITORS_SECTION_DELETED");
+        }
+        return sectionDTO;
+    }
 }


### PR DESCRIPTION
## Description

Ticket # and link

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2526

related pr: https://github.com/cabinetoffice/gap-find-apply-web/pull/421

- Extracts multiple editor validation, 
- Application service now throws a conflict exception if the section doesn't exist when retrieving a question

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
