### PR TITLE
Fix schedule unpublish application forms and add logs upon failure

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormController.java
@@ -168,21 +168,18 @@ public class ApplicationFormController {
             @ApiResponse(responseCode = "404", description = "Application not found with given id",
                     content = @Content(mediaType = "application/json")), })
     @LambdasHeaderValidator
-    public ResponseEntity<Void> removeApplicationAttachedToGrantAdvert(@PathVariable @NotNull UUID grantAdvertId) {
+    public ResponseEntity<Void> removeApplicationAttachedToGrantAdvert(@PathVariable @NotNull final UUID grantAdvertId) {
         try {
-
-            Integer schemeId = grantAdvertService.getAdvertById(grantAdvertId).getScheme().getId();
-            Optional<ApplicationFormEntity> applicationForm = applicationFormService
-                    .getOptionalApplicationFromSchemeId(schemeId);
+            final Integer schemeId = grantAdvertService.getSchemeIdFromAdvert(grantAdvertId);
+            final Optional<ApplicationFormEntity> applicationForm = applicationFormService.getOptionalApplicationFromSchemeId(schemeId);
             if (applicationForm.isEmpty()) {
                 log.info("No application form attached to grant advert with id: " + grantAdvertId + " was found.");
                 return ResponseEntity.noContent().build();
             }
 
-            ApplicationFormPatchDTO applicationFormPatchDTO = new ApplicationFormPatchDTO();
+            final ApplicationFormPatchDTO applicationFormPatchDTO = new ApplicationFormPatchDTO();
             applicationFormPatchDTO.setApplicationStatus(ApplicationStatusEnum.REMOVED);
-            this.applicationFormService.patchApplicationForm(applicationForm.get().getGrantApplicationId(),
-                    applicationFormPatchDTO, true);
+            applicationFormService.patchApplicationForm(applicationForm.get().getGrantApplicationId(), applicationFormPatchDTO, true);
 
             return ResponseEntity.noContent().build();
         }
@@ -192,10 +189,10 @@ public class ApplicationFormController {
         catch (UnauthorizedException error) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        catch (ApplicationFormException error) {
+        catch (Exception error) {
+            log.error("Error removing application attached to grant advert with id: " + grantAdvertId, error);
             return ResponseEntity.internalServerError().build();
         }
-
     }
 
     @PatchMapping("/{applicationId}")

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/GrantAdvertRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/repositories/GrantAdvertRepository.java
@@ -18,6 +18,10 @@ public interface GrantAdvertRepository extends JpaRepository<GrantAdvert, UUID> 
     @Override
     Optional<GrantAdvert> findById(UUID id);
 
+    @Query("select g from GrantAdvert g where g.id = ?1")
+    @EntityGraph(attributePaths = {"scheme"})
+    Optional<GrantAdvert> findByIdWithScheme(UUID id);
+
     @PreAuthorize("#grantAdminId == authentication.principal.grantAdminId")
     Long deleteByIdAndCreatedById(UUID advertId, Integer grantAdminId);
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/ApplicationFormService.java
@@ -355,7 +355,6 @@ public class ApplicationFormService {
             throw new ApplicationFormException("Error occurred when patching application with id of " + applicationId,
                     e);
         }
-
     }
 
     @PreAuthorize("hasRole('SUPER_ADMIN')")

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -126,6 +126,13 @@ public class GrantAdvertService {
         return advert;
     }
 
+    public Integer getSchemeIdFromAdvert(UUID advertId) {
+        return grantAdvertRepository.findByIdWithScheme(advertId)
+                .map(GrantAdvert::getScheme)
+                .map(SchemeEntity::getId)
+                .orElseThrow(() -> new NotFoundException("Scheme not found for advert with id " + advertId));
+    }
+
     public GetGrantAdvertPageResponseDTO getAdvertBuilderPageData(UUID grantAdvertId, String sectionId, String pageId) {
 
         GrantAdvert grantAdvert = getAdvertById(grantAdvertId);

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/ApplicationFormControllerTest.java
@@ -291,8 +291,7 @@ class ApplicationFormControllerTest {
     @Test
     void removesApplicationAttachedToGrantAdvert_Successfully() throws Exception {
         SchemeEntity scheme = SchemeEntity.builder().id(1).name("scheme").build();
-        GrantAdvert grantAdvert = GrantAdvert.builder().grantAdvertName("grant-advert").scheme(scheme).build();
-        when(grantAdvertService.getAdvertById(SAMPLE_ADVERT_ID)).thenReturn(grantAdvert);
+        when(grantAdvertService.getSchemeIdFromAdvert(SAMPLE_ADVERT_ID)).thenReturn(1);
         when(applicationFormService.getOptionalApplicationFromSchemeId(scheme.getId()))
                 .thenReturn(Optional.of(ApplicationFormEntity.builder().grantApplicationId(1)
                         .applicationName("application").grantSchemeId(scheme.getId()).build()));
@@ -310,7 +309,7 @@ class ApplicationFormControllerTest {
 
     @Test
     void removesApplicationAttachedToGrantAdvert_throwsNotFoundWhenNoAdvertFound() throws Exception {
-        doThrow(NotFoundException.class).when(grantAdvertService).getAdvertById(SAMPLE_ADVERT_ID);
+        doThrow(NotFoundException.class).when(grantAdvertService).getSchemeIdFromAdvert(SAMPLE_ADVERT_ID);
 
         this.mockMvc
                 .perform(delete("/application-forms/lambda/" + SAMPLE_ADVERT_ID + "/application/")
@@ -321,8 +320,7 @@ class ApplicationFormControllerTest {
     @Test
     void removesApplicationAttachedToGrantAdvert_throwsApplicationFormExceptionWhenUnableToPatch() throws Exception {
         SchemeEntity scheme = SchemeEntity.builder().id(1).name("scheme").build();
-        GrantAdvert grantAdvert = GrantAdvert.builder().grantAdvertName("grant-advert").scheme(scheme).build();
-        when(grantAdvertService.getAdvertById(SAMPLE_ADVERT_ID)).thenReturn(grantAdvert);
+        when(grantAdvertService.getSchemeIdFromAdvert(SAMPLE_ADVERT_ID)).thenReturn(1);
         when(applicationFormService.getOptionalApplicationFromSchemeId(scheme.getId()))
                 .thenReturn(Optional.of(ApplicationFormEntity.builder().grantApplicationId(1)
                         .applicationName("application").grantSchemeId(scheme.getId()).build()));


### PR DESCRIPTION
Noticed the scheduled job consistently fails to unpublish an application form. As this endpoint does not log anything upon exceptions thrown in certain places its impossible to be sure why, but the data looks sensible.

- Adding a log upon any exception
- Eagerly fetching scheme so we can grab the schemesId from the advert entity