### PR TITLE
use LocalDateTime for grant opening and closing times

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/grantadvert/GetGrantAdvertPublishingInformationResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -18,9 +19,9 @@ public class GetGrantAdvertPublishingInformationResponseDTO {
 
     private UUID grantAdvertId;
 
-    private Instant openingDate;
+    private LocalDateTime openingDate;
 
-    private Instant closingDate;
+    private LocalDateTime closingDate;
 
     private Instant firstPublishedDate;
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdvert.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/entities/GrantAdvert.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @EntityListeners(AuditingEntityListener.class)
@@ -60,10 +61,10 @@ public class GrantAdvert extends BaseEntity {
     private GrantAdmin lastUpdatedBy;
 
     @Column(name = "opening_date")
-    private Instant openingDate;
+    private LocalDateTime openingDate;
 
     @Column(name = "closing_date")
-    private Instant closingDate;
+    private LocalDateTime closingDate;
 
     @Column(name = "first_published_date")
     private Instant firstPublishedDate;

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertService.java
@@ -566,18 +566,16 @@ public class GrantAdvertService {
         int[] closingResponse = Arrays.stream(closingDateQuestion.getMultiResponse()).mapToInt(Integer::parseInt)
                 .toArray();
 
-        // build LocalDateTimes, convert to Instant
-        Instant openingDateInstant = LocalDateTime
-                .of(openingResponse[2], openingResponse[1], openingResponse[0], openingResponse[3], openingResponse[4])
-                .atZone(ZoneId.of("Z")).toInstant();
+        // build LocalDateTimes
+        LocalDateTime openingDate = LocalDateTime
+                .of(openingResponse[2], openingResponse[1], openingResponse[0], openingResponse[3], openingResponse[4]);
 
-        Instant closingDateInstant = LocalDateTime
-                .of(closingResponse[2], closingResponse[1], closingResponse[0], closingResponse[3], closingResponse[4])
-                .atZone(ZoneId.of("Z")).toInstant();
+        LocalDateTime closingDate = LocalDateTime
+                .of(closingResponse[2], closingResponse[1], closingResponse[0], closingResponse[3], closingResponse[4]);
 
         // set dates on advert
-        grantAdvert.setOpeningDate(openingDateInstant);
-        grantAdvert.setClosingDate(closingDateInstant);
+        grantAdvert.setOpeningDate(openingDate);
+        grantAdvert.setClosingDate(closingDate);
     }
 
     public void unscheduleGrantAdvert(final UUID advertId) {

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -449,9 +449,9 @@ class GrantAdvertControllerTest {
 
         private final Instant dateTimeInput = Instant.parse("2022-01-01T00:00:00.00Z");
 
-        private final LocalDateTime openingDate = LocalDateTime.from(dateTimeInput);
+        private final LocalDateTime openingDate = LocalDateTime.parse("2022-01-01T00:00:00.00");
 
-        private final LocalDateTime closingDate = LocalDateTime.from(dateTimeInput);
+        private final LocalDateTime closingDate = LocalDateTime.parse("2022-01-01T00:00:00.00");
 
         private final Instant firstPublishedDate = dateTimeInput;
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.validation.Validator;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
@@ -448,9 +449,9 @@ class GrantAdvertControllerTest {
 
         private final Instant dateTimeInput = Instant.parse("2022-01-01T00:00:00.00Z");
 
-        private final Instant openingDate = dateTimeInput;
+        private final LocalDateTime openingDate = LocalDateTime.from(dateTimeInput);
 
-        private final Instant closingDate = dateTimeInput;
+        private final LocalDateTime closingDate = LocalDateTime.from(dateTimeInput);
 
         private final Instant firstPublishedDate = dateTimeInput;
 

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -738,14 +738,13 @@ class GrantAdvertServiceTest {
                 .id("grantApplicationOpenDate").seen(true)
                 .multiResponse(new String[] { "10", "12", "2022", "00", "01" }).build();
 
-        final Instant openingDate = LocalDateTime.of(2022, 12, 10, 0, 1).atZone(ZoneId.of("Europe/London")).toInstant();
+        final LocalDateTime openingDate = LocalDateTime.of(2022, 12, 10, 0, 1);
 
         final GrantAdvertQuestionResponse response5 = GrantAdvertQuestionResponse.builder()
                 .id("grantApplicationCloseDate").seen(true)
                 .multiResponse(new String[] { "10", "12", "2023", "23", "59" }).build();
 
-        final Instant closingDate = LocalDateTime.of(2023, 12, 10, 23, 59).atZone(ZoneId.of("Europe/London"))
-                .toInstant();
+        final LocalDateTime closingDate = LocalDateTime.of(2023, 12, 10, 23, 59);
 
         final GrantAdvertQuestionResponse response6 = GrantAdvertQuestionResponse.builder().id("grantTotalAwardAmount")
                 .response("1000000").seen(true).build();
@@ -1222,14 +1221,13 @@ class GrantAdvertServiceTest {
                 .id("grantApplicationOpenDate").seen(true).multiResponse(new String[] { "10", "12", "2022", "0", "1" })
                 .build();
 
-        final Instant openingDate = LocalDateTime.of(2022, 12, 10, 0, 1).atZone(ZoneId.of("Europe/London")).toInstant();
+        final LocalDateTime openingDate = LocalDateTime.of(2022, 12, 10, 0, 1);
 
         final GrantAdvertQuestionResponse response5 = GrantAdvertQuestionResponse.builder()
                 .id("grantApplicationCloseDate").seen(true)
                 .multiResponse(new String[] { "10", "12", "2023", "23", "59" }).build();
 
-        final Instant closingDate = LocalDateTime.of(2023, 12, 10, 23, 59).atZone(ZoneId.of("Europe/London"))
-                .toInstant();
+        final LocalDateTime closingDate = LocalDateTime.of(2023, 12, 10, 23, 59);
 
         final GrantAdvertPageResponse datesPage = GrantAdvertPageResponse.builder().id("1")
                 .status(GrantAdvertPageResponseStatus.COMPLETED).questions(List.of(response4, response5)).build();


### PR DESCRIPTION
## Description

Our logic converting the times to `Instant` types was stripping the timezone without adjusting the value; this change uses `LocalDateTime` for these values instead, allowing postgres to convert the values for us when saving and retrieving from the database.

>For timestamp with time zone, the internally stored value is always in UTC (Universal Coordinated Time, traditionally known as Greenwich Mean Time, GMT). An input value that has an explicit time zone specified is converted to UTC using the appropriate offset for that time zone. If no time zone is stated in the input string, then it is assumed to be in the time zone indicated by the system's [TimeZone](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TIMEZONE) parameter, and is converted to UTC using the offset for the timezone zone.

https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT-TIME-STAMPS

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
