### PR TITLE
GAP-2592: daylight savings causing time to be off by one hour

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/controllers/GrantAdvertController.java
@@ -92,14 +92,21 @@ public class GrantAdvertController {
     public ResponseEntity updatePage(HttpServletRequest request, @PathVariable UUID grantAdvertId,
             @PathVariable String sectionId, @PathVariable String pageId,
             @RequestBody @NotNull GrantAdvertPagePatchResponseDto patchAdvertPageResponse) {
-        GrantAdvertPageResponse responseWithId = GrantAdvertPageResponse.builder().id(pageId)
-                .status(patchAdvertPageResponse.getStatus()).questions(patchAdvertPageResponse.getQuestions()).build();
+        GrantAdvertPageResponse responseWithId = GrantAdvertPageResponse.builder()
+                .id(pageId)
+                .status(patchAdvertPageResponse.getStatus())
+                .questions(patchAdvertPageResponse.getQuestions())
+                .build();
+
         GrantAdvertPageResponseValidationDto patchPageDto = GrantAdvertPageResponseValidationDto.builder()
-                .grantAdvertId(grantAdvertId).sectionId(sectionId).page(responseWithId).build();
-        // given we need sectionId to validate the Dto, we can't validate in the
-        // controller method
-        Set<ConstraintViolation<GrantAdvertPageResponseValidationDto>> validationErrorsSet = validator
-                .validate(patchPageDto);
+                .grantAdvertId(grantAdvertId)
+                .sectionId(sectionId)
+                .page(responseWithId)
+                .build();
+
+        // given we need sectionId to validate the Dto, we can't validate in the controller method
+        Set<ConstraintViolation<GrantAdvertPageResponseValidationDto>> validationErrorsSet =
+                validator.validate(patchPageDto);
 
         if (!validationErrorsSet.isEmpty()) {
             List<ValidationError> validationErrorsList = reorderValidationErrors(patchAdvertPageResponse,
@@ -111,11 +118,13 @@ public class GrantAdvertController {
 
         try {
             AdminSession session = HelperUtils.getAdminSessionForAuthenticatedUser();
-            eventLogService.logAdvertUpdatedEvent(request.getRequestedSessionId(), session.getUserSub(),
-                    session.getFunderId(), grantAdvertId.toString());
-        }
-        catch (Exception e) {
-            // If anything goes wrong logging to event service, log and continue
+            eventLogService.logAdvertUpdatedEvent(
+                    request.getRequestedSessionId(),
+                    session.getUserSub(),
+                    session.getFunderId(),
+                    grantAdvertId.toString()
+            );
+        } catch (Exception e) {
             log.error("Could not send to event service. Exception: ", e);
         }
 

--- a/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/pages/AdvertSummaryPageDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/adminbackend/dtos/pages/AdvertSummaryPageDTO.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,6 +24,9 @@ public class AdvertSummaryPageDTO {
     private List<AdvertSummaryPageSectionDTO> sections;
 
     private GrantAdvertStatus status;
+
+    private ZonedDateTime openingDate;
+    private ZonedDateTime closingDate;
 
     @Data
     @AllArgsConstructor

--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/GrantAdvertServiceTest.java
@@ -614,30 +614,55 @@ class GrantAdvertServiceTest {
             final GrantAdvert advert = GrantAdvert.builder().build();
 
             String[] openingMultiResponse = new String[]{"10", "10", "2010", "13:00"};
-            GrantAdvertQuestionResponse openingDateQuestion = GrantAdvertQuestionResponse.builder().id(OPENING_DATE_ID)
-                    .multiResponse(openingMultiResponse).build();
+            GrantAdvertQuestionResponse openingDateQuestion = GrantAdvertQuestionResponse.builder()
+                    .id(OPENING_DATE_ID)
+                    .multiResponse(openingMultiResponse)
+                    .build();
+
             String[] closingMultiResponse = new String[]{"12", "12", "2012", "13:00"};
-            GrantAdvertQuestionResponse closingDateQuestion = GrantAdvertQuestionResponse.builder().id(CLOSING_DATE_ID)
-                    .multiResponse(closingMultiResponse).build();
+            GrantAdvertQuestionResponse closingDateQuestion = GrantAdvertQuestionResponse.builder()
+                    .id(CLOSING_DATE_ID)
+                    .multiResponse(closingMultiResponse)
+                    .build();
+
             String[] expectedOpeningMultiResponse = new String[]{"10", "10", "2010", "13", "00"};
             String[] expectedClosingMultiResponse = new String[]{"12", "12", "2012", "13", "00"};
 
-            GrantAdvertPageResponse datePage = GrantAdvertPageResponse.builder().id(pageId)
+            GrantAdvertPageResponse datePage = GrantAdvertPageResponse.builder()
+                    .id("1")
                     .status(GrantAdvertPageResponseStatus.COMPLETED)
-                    .questions(List.of(openingDateQuestion, closingDateQuestion)).build();
+                    .questions(List.of(openingDateQuestion, closingDateQuestion))
+                    .build();
 
             GrantAdvertPageResponseValidationDto datePagePatchDto = GrantAdvertPageResponseValidationDto.builder()
-                    .grantAdvertId(grantAdvertId).sectionId(ADVERT_DATES_SECTION_ID).page(datePage).build();
+                    .grantAdvertId(grantAdvertId)
+                    .sectionId(ADVERT_DATES_SECTION_ID)
+                    .page(datePage)
+                    .build();
 
-            AdvertDefinitionQuestion openDateDefinitionQuestion = AdvertDefinitionQuestion.builder().id(OPENING_DATE_ID)
+            AdvertDefinitionQuestion openDateDefinitionQuestion = AdvertDefinitionQuestion.builder()
+                    .id(OPENING_DATE_ID)
                     .responseType(AdvertDefinitionQuestionResponseType.DATE)
-                    .validation(AdvertDefinitionQuestionValidation.builder().mandatory(true).build()).build();
+                    .validation(AdvertDefinitionQuestionValidation.builder()
+                            .mandatory(true)
+                            .build()
+                    )
+                    .build();
             AdvertDefinitionQuestion closeDateDefinitionQuestion = AdvertDefinitionQuestion.builder()
-                    .id(CLOSING_DATE_ID).responseType(AdvertDefinitionQuestionResponseType.DATE)
-                    .validation(AdvertDefinitionQuestionValidation.builder().mandatory(true).build()).build();
-            AdvertDefinitionSection definitionSection = AdvertDefinitionSection.builder().id(ADVERT_DATES_SECTION_ID)
-                    .pages(List.of(AdvertDefinitionPage.builder().id(pageId)
-                            .questions(List.of(openDateDefinitionQuestion, closeDateDefinitionQuestion)).build()))
+                    .id(CLOSING_DATE_ID)
+                    .responseType(AdvertDefinitionQuestionResponseType.DATE)
+                    .validation(AdvertDefinitionQuestionValidation.builder()
+                            .mandatory(true)
+                            .build()
+                    )
+                    .build();
+            AdvertDefinitionSection definitionSection = AdvertDefinitionSection.builder()
+                    .id(ADVERT_DATES_SECTION_ID)
+                    .pages(List.of(AdvertDefinitionPage.builder()
+                            .id("1")
+                            .questions(List.of(openDateDefinitionQuestion, closeDateDefinitionQuestion))
+                            .build())
+                    )
                     .build();
 
             when(grantAdvertRepository.findById(grantAdvertId))
@@ -655,7 +680,7 @@ class GrantAdvertServiceTest {
             Optional<GrantAdvertSectionResponse> sectionById = response.getSectionById(ADVERT_DATES_SECTION_ID);
             assertThat(sectionById).isPresent();
             assertThat(sectionById.get().getStatus()).isEqualTo(GrantAdvertSectionResponseStatus.COMPLETED);
-            Optional<GrantAdvertPageResponse> pageById = sectionById.get().getPageById(pageId);
+            Optional<GrantAdvertPageResponse> pageById = sectionById.get().getPageById("1");
             assertThat(pageById).isPresent();
             Optional<GrantAdvertQuestionResponse> openingQuestion = pageById.get().getQuestionById(OPENING_DATE_ID);
             assertThat(openingQuestion).isPresent();


### PR DESCRIPTION
## Description
if a user sets a grant to publish less than an hour in the past (IE, immediately) during daylight savings time then the "schedule" button will appear as the server operates on UTC and the conversion that determines whether the "schedule" button should appear or not does not take this potential difference in timezones into account. This change adds better handling of absolute date times. 

Ticket # and link
[GAP 2592](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2592)

Summary of the changes and the related issue. List any dependencies that are required for this change:
see above

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
