### PR TITLE
GAP-2586: Grants with rich text not publishing to open search

### DIFF
--- a/src/test/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/adminbackend/services/OpenSearchServiceTest.java
@@ -2,21 +2,19 @@ package gov.cabinetoffice.gap.adminbackend.services;
 
 import com.contentful.java.cma.model.CMAEntry;
 import com.contentful.java.cma.model.CMASystem;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cabinetoffice.gap.adminbackend.config.ContentfulConfigProperties;
 import gov.cabinetoffice.gap.adminbackend.config.OpenSearchConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
 import org.mockito.Spy;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import static org.mockito.Mockito.*;
 
 @SpringJUnitConfig
 class OpenSearchServiceTest {
@@ -31,7 +29,7 @@ class OpenSearchServiceTest {
     private WebClient.Builder webClientBuilder;
 
     @Mock
-    private ObjectMapper objectMapper;
+    private ContentfulConfigProperties contentfulProperties;
 
     private CMAEntry contentfulEntry;
 
@@ -53,12 +51,23 @@ class OpenSearchServiceTest {
         final WebClient mockWebClient = mock(WebClient.class);
         final WebClient.RequestBodyUriSpec mockRequestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
         final WebClient.RequestHeadersSpec mockRequestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        final WebClient.RequestHeadersUriSpec mockRequestHeadersUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
         final WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
-        final JsonNode mockJsonNode = mock(JsonNode.class);
 
-        when(objectMapper.valueToTree(any())).thenReturn(mockJsonNode);
-        when(mockJsonNode.toString()).thenReturn("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}");
+        when(contentfulProperties.getSpaceId()).thenReturn("Space");
+        when(contentfulProperties.getEnvironmentId()).thenReturn("environment");
+        when(contentfulProperties.getAccessToken()).thenReturn("accessToken");
+        when(contentfulProperties.getDeliveryAPIAccessToken()).thenReturn("deliveryAccessToken");
+
         when(webClientBuilder.build()).thenReturn(mockWebClient);
+
+        when(mockWebClient.get()).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.uri(anyString())).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.headers(any())).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.retrieve()).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.onStatus(any(), any())).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.bodyToMono(String.class)).thenReturn(Mono.just("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}"));
+
         when(mockWebClient.put()).thenReturn(mockRequestBodyUriSpec);
         when(mockRequestBodyUriSpec.uri("testUrl/testDomain/_doc/testId")).thenReturn(mockRequestBodyUriSpec);
         when(mockRequestBodyUriSpec.body(any(), eq(String.class))).thenReturn(mockRequestHeadersSpec);
@@ -68,6 +77,12 @@ class OpenSearchServiceTest {
         when(mockResponseSpec.bodyToMono(void.class)).thenReturn(Mono.empty());
 
         openSearchService.indexEntry(contentfulEntry);
+
+        verify(webClientBuilder.build().get(), times(1))
+                .uri("https://api.contentful.com/spaces/Space/environments/environment/entries/testId");
+
+        verify(webClientBuilder.build().put(), times(1))
+                .uri("testUrl/testDomain/_doc/testId");
     }
 
     @Test
@@ -76,11 +91,22 @@ class OpenSearchServiceTest {
         final WebClient.RequestBodyUriSpec mockRequestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
         final WebClient.RequestHeadersSpec mockRequestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
         final WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
-        final JsonNode mockJsonNode = mock(JsonNode.class);
+        final WebClient.RequestHeadersUriSpec mockRequestHeadersUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
 
-        when(objectMapper.valueToTree(any())).thenReturn(mockJsonNode);
-        when(mockJsonNode.toString()).thenReturn("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}");
+        when(contentfulProperties.getSpaceId()).thenReturn("Space");
+        when(contentfulProperties.getEnvironmentId()).thenReturn("environment");
+        when(contentfulProperties.getAccessToken()).thenReturn("accessToken");
+        when(contentfulProperties.getDeliveryAPIAccessToken()).thenReturn("deliveryAccessToken");
+
         when(webClientBuilder.build()).thenReturn(mockWebClient);
+
+        when(mockWebClient.get()).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.uri(anyString())).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.headers(any())).thenReturn(mockRequestHeadersUriSpec);
+        when(mockRequestHeadersUriSpec.retrieve()).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.onStatus(any(), any())).thenReturn(mockResponseSpec);
+        when(mockResponseSpec.bodyToMono(String.class)).thenReturn(Mono.just("{\"system\":{\"id\":\"testId\"},\"environmentId\":\"master\",\"id\":\"testId\",\"published\":false,\"archived\":false}"));
+
         when(mockWebClient.method(HttpMethod.DELETE)).thenReturn(mockRequestBodyUriSpec);
         when(mockRequestBodyUriSpec.uri("testUrl/testDomain/_doc/testId")).thenReturn(mockRequestBodyUriSpec);
         when(mockRequestBodyUriSpec.body(any(), eq(String.class))).thenReturn(mockRequestHeadersSpec);
@@ -90,5 +116,11 @@ class OpenSearchServiceTest {
         when(mockResponseSpec.bodyToMono(void.class)).thenReturn(Mono.empty());
 
         openSearchService.removeIndexEntry(contentfulEntry);
+
+        verify(webClientBuilder.build().get(), times(1))
+                .uri("https://api.contentful.com/spaces/Space/environments/environment/entries/testId");
+
+        verify(webClientBuilder.build().method(HttpMethod.DELETE), times(1))
+                .uri("testUrl/testDomain/_doc/testId");
     }
 }


### PR DESCRIPTION
## Description
If a grant contained rich text fields then it was silently dying inside the application because of a setting we had switched on inside our jackson data mapper. We've replaced this method of creating JSON with a method that just directly fetches it from contentful using HTTP. 

Ticket # and link
[GAP-2586
](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2586)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Changed the way we create the JSON that is sent to open search. 

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End-to-End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have run cypress tests, and they all pass locally.
